### PR TITLE
fix(aunit): parse external coverage measurement URI

### DIFF
--- a/packages/adt-contracts/src/adt/aunit/coverage-link.ts
+++ b/packages/adt-contracts/src/adt/aunit/coverage-link.ts
@@ -2,16 +2,17 @@
  * Coverage link helper for AUnit responses.
  *
  * When coverage is enabled on an ABAP Unit run, the aunit:runResult
- * contains an atom:link with `rel` referring to the coverage measurement.
- * Example:
+ * contains either an Atom link or an external coverage URI referring to the
+ * coverage measurement. Examples:
  *
  *   <atom:link href="/sap/bc/adt/runtime/traces/coverage/measurements/6D664D9B46CB1FE1859107ADE8729541"
  *              rel="http://www.sap.com/adt/relations/runtime/traces/coverage/measurements"/>
+ *   <external><coverage adtcore:uri="/sap/bc/adt/runtime/traces/coverage/measurements/6D664D9B46CB1FE1859107ADE8729541"/></external>
  *
  * The measurement ID is the hex segment after /measurements/.
  */
 
-const COVERAGE_MEASUREMENT_HREF_RE =
+const COVERAGE_MEASUREMENT_URI_RE =
   /\/sap\/bc\/adt\/runtime\/traces\/coverage\/measurements\/([A-Fa-f0-9]+)/;
 
 export interface CoverageLinkCandidate {
@@ -59,7 +60,13 @@ export function extractCoverageMeasurementId(
           ? ((link as CoverageLinkCandidate).href ?? undefined)
           : undefined;
       if (!href) continue;
-      const match = COVERAGE_MEASUREMENT_HREF_RE.exec(href);
+      const match = COVERAGE_MEASUREMENT_URI_RE.exec(href);
+      if (match) return match[1];
+    }
+
+    const uri = typeof obj.uri === 'string' ? obj.uri : undefined;
+    if (uri) {
+      const match = COVERAGE_MEASUREMENT_URI_RE.exec(uri);
       if (match) return match[1];
     }
 

--- a/packages/adt-contracts/tests/coverage-link.test.ts
+++ b/packages/adt-contracts/tests/coverage-link.test.ts
@@ -58,4 +58,13 @@ describe('extractCoverageMeasurementId', () => {
       '6D664D9B46CB1FE1859107ADE8729541',
     );
   });
+
+  it('preserves the external coverage URI returned by S0D', async () => {
+    const xml = await fixtures.aunit.runResultCoverageExternal.load();
+    const parsed = aunitResult.parse(xml);
+
+    expect(extractCoverageMeasurementId(parsed)).toBe(
+      '06B02025CD671FD1A7B6AB1C7D024677',
+    );
+  });
 });

--- a/packages/adt-fixtures/src/fixtures/aunit/run-result-coverage-external.xml
+++ b/packages/adt-fixtures/src/fixtures/aunit/run-result-coverage-external.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+  <external>
+    <coverage xmlns:adtcore="http://www.sap.com/adt/core"
+      adtcore:uri="/sap/bc/adt/runtime/traces/coverage/measurements/06B02025CD671FD1A7B6AB1C7D024677"/>
+  </external>
+  <program xmlns:adtcore="http://www.sap.com/adt/core"
+    adtcore:uri="/sap/bc/adt/oo/classes/zcl_example"
+    adtcore:type="CLAS/OC"
+    adtcore:name="ZCL_EXAMPLE"
+    uriType="semantic"/>
+</aunit:runResult>

--- a/packages/adt-fixtures/src/fixtures/registry.ts
+++ b/packages/adt-fixtures/src/fixtures/registry.ts
@@ -27,6 +27,7 @@ export const registry = {
     runRequest: 'aunit/run-request.xml',
     runResult: 'aunit/run-result.xml',
     runResultCoverageLink: 'aunit/run-result-coverage-link.xml',
+    runResultCoverageExternal: 'aunit/run-result-coverage-external.xml',
     // Sourced from jfilak/sapcli test fixtures (fixtures_adt_acoverage /
     // fixtures_adt_coverage). Real sanitized SAP responses for the
     // /runtime/traces/coverage endpoints.

--- a/packages/adt-schemas/.xsd/custom/adtcoreObjectSets.xsd
+++ b/packages/adt-schemas/.xsd/custom/adtcoreObjectSets.xsd
@@ -21,6 +21,21 @@
   <!-- Global element for namespace-qualified adtcore:objectSets -->
   <xsd:element name="objectSets" type="adtcore:AdtObjectSets"/>
 
+  <!--
+    Global attribute declarations for ADT core attributes that SAP qualifies
+    with the adtcore: prefix in AUnit, ATC, and coverage responses.
+
+    adtcore.xsd declares these as local attributes inside complexTypes (e.g.
+    AdtObject), but never as top-level globals.  Other namespaces that need
+    to reference adtcore:uri / adtcore:type / adtcore:name / adtcore:description
+    via xsd:attribute ref="adtcore:..." require global declarations in the
+    adtcore target namespace, which this extension provides.
+  -->
+  <xsd:attribute name="uri" type="xsd:anyURI"/>
+  <xsd:attribute name="type" type="xsd:string"/>
+  <xsd:attribute name="name" type="xsd:string"/>
+  <xsd:attribute name="description" type="xsd:string"/>
+
   <xsd:complexType name="AdtObjectSets">
     <xsd:sequence>
       <xsd:element name="objectSet" type="adtcore:AdtObjectSet" minOccurs="0" maxOccurs="unbounded" form="unqualified"/>

--- a/packages/adt-schemas/.xsd/custom/aunitResult.xsd
+++ b/packages/adt-schemas/.xsd/custom/aunitResult.xsd
@@ -46,9 +46,21 @@
   <!-- Run Result -->
   <xsd:complexType name="AunitRunResult">
     <xsd:sequence>
+      <xsd:element name="external" type="aunit:AunitExternal" minOccurs="0" maxOccurs="1" form="unqualified"/>
       <xsd:element ref="atom:link" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="program" type="aunit:AunitProgram" minOccurs="0" maxOccurs="unbounded" form="unqualified"/>
     </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- Coverage-enabled systems may return the measurement as external/coverage/@adtcore:uri. -->
+  <xsd:complexType name="AunitExternal">
+    <xsd:sequence>
+      <xsd:element name="coverage" type="aunit:AunitCoverage" minOccurs="0" maxOccurs="1" form="unqualified"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="AunitCoverage">
+    <xsd:attribute name="uri" type="xsd:anyURI"/>
   </xsd:complexType>
 
   <!-- Program -->

--- a/packages/adt-schemas/.xsd/custom/aunitResult.xsd
+++ b/packages/adt-schemas/.xsd/custom/aunitResult.xsd
@@ -33,12 +33,14 @@
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:aunit="http://www.sap.com/adt/aunit"
+    xmlns:adtcore="http://www.sap.com/adt/core"
     xmlns:atom="http://www.w3.org/2005/Atom"
     targetNamespace="http://www.sap.com/adt/aunit"
     elementFormDefault="qualified"
     attributeFormDefault="unqualified">
 
   <xsd:import namespace="http://www.w3.org/2005/Atom" schemaLocation="../sap/atom.xsd"/>
+  <xsd:import namespace="http://www.sap.com/adt/core" schemaLocation="adtcoreObjectSets.xsd"/>
 
   <!-- Root element -->
   <xsd:element name="runResult" type="aunit:AunitRunResult"/>
@@ -60,7 +62,7 @@
   </xsd:complexType>
 
   <xsd:complexType name="AunitCoverage">
-    <xsd:attribute name="uri" type="xsd:anyURI"/>
+    <xsd:attribute ref="adtcore:uri"/>
   </xsd:complexType>
 
   <!-- Program -->
@@ -69,9 +71,9 @@
       <xsd:element name="testClasses" type="aunit:AunitTestClasses" minOccurs="0" maxOccurs="1" form="unqualified"/>
       <xsd:element name="alerts" type="aunit:AunitAlerts" minOccurs="0" maxOccurs="1" form="unqualified"/>
     </xsd:sequence>
-    <xsd:attribute name="uri" type="xsd:anyURI"/>
-    <xsd:attribute name="type" type="xsd:string"/>
-    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute ref="adtcore:uri"/>
+    <xsd:attribute ref="adtcore:type"/>
+    <xsd:attribute ref="adtcore:name"/>
     <xsd:attribute name="uriType" type="xsd:string"/>
   </xsd:complexType>
 
@@ -88,8 +90,8 @@
       <xsd:element name="testMethods" type="aunit:AunitTestMethods" minOccurs="0" maxOccurs="1" form="unqualified"/>
       <xsd:element name="alerts" type="aunit:AunitAlerts" minOccurs="0" maxOccurs="1" form="unqualified"/>
     </xsd:sequence>
-    <xsd:attribute name="uri" type="xsd:anyURI"/>
-    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute ref="adtcore:uri"/>
+    <xsd:attribute ref="adtcore:name"/>
     <xsd:attribute name="uriType" type="xsd:string"/>
     <xsd:attribute name="durationCategory" type="xsd:string"/>
     <xsd:attribute name="riskLevel" type="xsd:string"/>
@@ -107,8 +109,8 @@
     <xsd:sequence>
       <xsd:element name="alerts" type="aunit:AunitAlerts" minOccurs="0" maxOccurs="1" form="unqualified"/>
     </xsd:sequence>
-    <xsd:attribute name="uri" type="xsd:anyURI"/>
-    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute ref="adtcore:uri"/>
+    <xsd:attribute ref="adtcore:name"/>
     <xsd:attribute name="executionTime" type="xsd:string"/>
     <xsd:attribute name="uriType" type="xsd:string"/>
     <xsd:attribute name="unit" type="xsd:string"/>
@@ -153,10 +155,10 @@
 
   <!-- Stack Entry -->
   <xsd:complexType name="AunitStackEntry">
-    <xsd:attribute name="uri" type="xsd:anyURI"/>
-    <xsd:attribute name="type" type="xsd:string"/>
-    <xsd:attribute name="name" type="xsd:string"/>
-    <xsd:attribute name="description" type="xsd:string"/>
+    <xsd:attribute ref="adtcore:uri"/>
+    <xsd:attribute ref="adtcore:type"/>
+    <xsd:attribute ref="adtcore:name"/>
+    <xsd:attribute ref="adtcore:description"/>
   </xsd:complexType>
 
 </xsd:schema>

--- a/packages/adt-schemas/src/schemas/generated/schemas/custom/adtcoreObjectSets.ts
+++ b/packages/adt-schemas/src/schemas/generated/schemas/custom/adtcoreObjectSets.ts
@@ -22,6 +22,24 @@ export default {
       type: 'adtcore:AdtObjectSets',
     },
   ],
+  attribute: [
+    {
+      name: 'uri',
+      type: 'xsd:anyURI',
+    },
+    {
+      name: 'type',
+      type: 'xsd:string',
+    },
+    {
+      name: 'name',
+      type: 'xsd:string',
+    },
+    {
+      name: 'description',
+      type: 'xsd:string',
+    },
+  ],
   complexType: [
     {
       name: 'AdtObjectSets',

--- a/packages/adt-schemas/src/schemas/generated/schemas/custom/aunitResult.ts
+++ b/packages/adt-schemas/src/schemas/generated/schemas/custom/aunitResult.ts
@@ -31,6 +31,13 @@ export default {
       sequence: {
         element: [
           {
+            name: 'external',
+            type: 'aunit:AunitExternal',
+            minOccurs: '0',
+            maxOccurs: '1',
+            form: 'unqualified',
+          },
+          {
             ref: 'atom:link',
             minOccurs: '0',
             maxOccurs: 'unbounded',
@@ -44,6 +51,29 @@ export default {
           },
         ],
       },
+    },
+    {
+      name: 'AunitExternal',
+      sequence: {
+        element: [
+          {
+            name: 'coverage',
+            type: 'aunit:AunitCoverage',
+            minOccurs: '0',
+            maxOccurs: '1',
+            form: 'unqualified',
+          },
+        ],
+      },
+    },
+    {
+      name: 'AunitCoverage',
+      attribute: [
+        {
+          name: 'uri',
+          type: 'xsd:anyURI',
+        },
+      ],
     },
     {
       name: 'AunitProgram',

--- a/packages/adt-schemas/src/schemas/generated/schemas/custom/aunitResult.ts
+++ b/packages/adt-schemas/src/schemas/generated/schemas/custom/aunitResult.ts
@@ -6,15 +6,18 @@
  */
 
 import atom from '../sap/atom';
+import adtcoreObjectSets from './adtcoreObjectSets';
 
 export default {
   $xmlns: {
     xsd: 'http://www.w3.org/2001/XMLSchema',
     aunit: 'http://www.sap.com/adt/aunit',
+    adtcore: 'http://www.sap.com/adt/core',
     atom: 'http://www.w3.org/2005/Atom',
   },
   $imports: [
     atom,
+    adtcoreObjectSets,
   ],
   targetNamespace: 'http://www.sap.com/adt/aunit',
   attributeFormDefault: 'unqualified',
@@ -70,8 +73,7 @@ export default {
       name: 'AunitCoverage',
       attribute: [
         {
-          name: 'uri',
-          type: 'xsd:anyURI',
+          ref: 'adtcore:uri',
         },
       ],
     },
@@ -97,16 +99,13 @@ export default {
       },
       attribute: [
         {
-          name: 'uri',
-          type: 'xsd:anyURI',
+          ref: 'adtcore:uri',
         },
         {
-          name: 'type',
-          type: 'xsd:string',
+          ref: 'adtcore:type',
         },
         {
-          name: 'name',
-          type: 'xsd:string',
+          ref: 'adtcore:name',
         },
         {
           name: 'uriType',
@@ -150,12 +149,10 @@ export default {
       },
       attribute: [
         {
-          name: 'uri',
-          type: 'xsd:anyURI',
+          ref: 'adtcore:uri',
         },
         {
-          name: 'name',
-          type: 'xsd:string',
+          ref: 'adtcore:name',
         },
         {
           name: 'uriType',
@@ -200,12 +197,10 @@ export default {
       },
       attribute: [
         {
-          name: 'uri',
-          type: 'xsd:anyURI',
+          ref: 'adtcore:uri',
         },
         {
-          name: 'name',
-          type: 'xsd:string',
+          ref: 'adtcore:name',
         },
         {
           name: 'executionTime',
@@ -314,20 +309,16 @@ export default {
       name: 'AunitStackEntry',
       attribute: [
         {
-          name: 'uri',
-          type: 'xsd:anyURI',
+          ref: 'adtcore:uri',
         },
         {
-          name: 'type',
-          type: 'xsd:string',
+          ref: 'adtcore:type',
         },
         {
-          name: 'name',
-          type: 'xsd:string',
+          ref: 'adtcore:name',
         },
         {
-          name: 'description',
-          type: 'xsd:string',
+          ref: 'adtcore:description',
         },
       ],
     },

--- a/packages/adt-schemas/src/schemas/generated/types/custom/aunitResult.types.ts
+++ b/packages/adt-schemas/src/schemas/generated/types/custom/aunitResult.types.ts
@@ -7,6 +7,11 @@
 
 export type AunitResultSchema = {
     runResult: {
+        external?: undefined | {
+            coverage?: undefined | {
+                uri?: string | undefined;
+            };
+        };
         link?: undefined | {
             href: string;
             rel?: string | undefined;


### PR DESCRIPTION
## **User description**
## Summary

Support the coverage measurement response shape returned by SAP S0D, where the AUnit result exposes the measurement under `external/coverage/@adtcore:uri` instead of an Atom link.

## Live evidence

A real S0D class run produced 38 passing ABAP Unit tests and returned this sanitized shape:

```xml
<external>
  <coverage adtcore:uri="/sap/bc/adt/runtime/traces/coverage/measurements/06B02025CD671FD1A7B6AB1C7D024677"/>
</external>
```

The existing parser dropped `external`, so `extractCoverageMeasurementId()` returned `undefined` and the CLI warned that SAP had returned no measurement link.

## Changes

- model the optional `external/coverage/@uri` result in `aunitResult.xsd`
- preserve it in generated schema/types
- extract measurement IDs from either Atom `href` or coverage `uri`
- add a sanitized real-response fixture and parser regression test

## Verification

- focused regression: 5/5 passed
- `adt-contracts:test`: passed
- `adt-contracts:lint`: passed
- `adt-schemas:test`, `typecheck`, and `lint`: passed

`adt-contracts:typecheck` still reports the pre-existing unused `describe`/`it` imports in `tests/contracts/coverage.test.ts`; this PR does not touch that file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse AUnit coverage measurement when SAP returns an external coverage URI instead of an Atom link. Previously we only read the Atom href and warned; now we extract the measurement ID from either format and align schemas with SAP’s qualified `adtcore:*` attributes.

- Import `adtcore` in `aunitResult.xsd`, add `external/coverage@adtcore:uri`, and declare global `adtcore` attributes in `adtcoreObjectSets.xsd`.
- Regenerate schema literals and types in `adt-schemas`; TypeScript interfaces remain compatible and only gain optional fields.
- Update `extractCoverageMeasurementId` to read IDs from Atom links or external coverage URIs; add an S0D fixture and a regression test in `adt-fixtures` and `adt-contracts`.
- No migration required; removes the false “no measurement link” warning.

<sup>Written for commit 0537f668349d6b3ab0b2502a8fd6e6a60c72f699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Parse coverage measurements returned in external AUnit responses

### What Changed
- AUnit coverage results can now be read when SAP returns the measurement URI under `external/coverage`, as well as through the existing Atom link.
- Responses using the external coverage format are preserved and converted into the correct measurement ID.
- Added coverage response data and regression coverage for the new format.

### Impact
`✅ Coverage results work with SAP S0D responses`
`✅ Fewer missing coverage measurement warnings`
`✅ Existing Atom coverage links remain supported`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coverage measurement detection for AUnit test results.
  - Coverage identifiers are now recognized through external coverage references as well as standard links.
  - Preserves externally returned coverage measurement URIs for downstream reporting and analysis.
  - Improved compatibility when processing coverage, program, test, and stack information from AUnit results.

- **Tests**
  - Added coverage for AUnit results that reference external measurements.
  - Added representative test data for externally linked coverage results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->