### PR TITLE
fix(client): support long-running SAP requests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,6 +186,7 @@
         "@abapify/adt-contracts": "0.4.1",
         "@abapify/adt-schemas": "0.4.1",
         "@abapify/logger": "0.4.1",
+        "undici": "^8.10.0",
       },
     },
     "packages/adt-codegen": {
@@ -4903,7 +4904,9 @@
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
+
+    "cheerio/undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/packages/adt-cli/README.md
+++ b/packages/adt-cli/README.md
@@ -305,7 +305,8 @@ response-header timeout, set a positive millisecond value:
 ADT_HEADERS_TIMEOUT_MS=900000 adt aunit --transport NPLK900042
 ```
 
-Leave the variable unset for the native default. Invalid, zero, or fractional
+Leave the variable unset (or set it to an empty string) for the native
+default — both are treated equivalently. Invalid, zero, or fractional
 values fail before the request is sent.
 
 ## Command Reference

--- a/packages/adt-cli/README.md
+++ b/packages/adt-cli/README.md
@@ -298,6 +298,16 @@ ADT_LOG_COMPONENTS=auth,http adt auth login --file service-key.json
 
 Available log levels: `trace`, `debug`, `info`, `warn`, `error`, `fatal`.
 
+For SAP operations that legitimately take longer than the native HTTP client's
+response-header timeout, set a positive millisecond value:
+
+```bash
+ADT_HEADERS_TIMEOUT_MS=900000 adt aunit --transport NPLK900042
+```
+
+Leave the variable unset for the native default. Invalid, zero, or fractional
+values fail before the request is sent.
+
 ## Command Reference
 
 | Command                             | Description                       |

--- a/packages/adt-cli/src/lib/utils/adt-client-v2.ts
+++ b/packages/adt-cli/src/lib/utils/adt-client-v2.ts
@@ -35,6 +35,7 @@ import {
   type ProgressReporter,
 } from './progress-reporter';
 import { setAdtSystem } from '../ui/components/link';
+import { resolveAdtHeadersTimeoutMs } from './adt-http-options';
 
 // Re-export shared state from shared/adt-client.ts for backward compatibility
 export {
@@ -510,6 +511,7 @@ export async function getAdtClientV2(
     logger,
     plugins,
     onSessionExpired,
+    headersTimeoutMs: resolveAdtHeadersTimeoutMs(),
   });
 
   // Initialize ADK global context if not already done
@@ -719,6 +721,7 @@ export async function getAdtClientV2Safe(
     logger,
     plugins,
     onSessionExpired,
+    headersTimeoutMs: resolveAdtHeadersTimeoutMs(),
   });
 
   if (!isAdkInitialized()) {

--- a/packages/adt-cli/src/lib/utils/adt-client-v2.ts
+++ b/packages/adt-cli/src/lib/utils/adt-client-v2.ts
@@ -555,8 +555,9 @@ export async function getAdtClientV2Safe(
     return testOverride;
   }
 
-  // Fail fast on an invalid timeout before any auth/refresh work.
-  const headersTimeoutMs = resolveAdtHeadersTimeoutMs();
+  // Validate the headers timeout up front so an invalid value fails before
+  // any expired-session refresh or authentication work can send a request.
+  const adtHeadersTimeout = resolveAdtHeadersTimeoutMs();
 
   const ctx = getCliContext();
   const effectiveOptions = {
@@ -728,7 +729,7 @@ export async function getAdtClientV2Safe(
     logger,
     plugins,
     onSessionExpired,
-    headersTimeoutMs,
+    headersTimeoutMs: adtHeadersTimeout,
   });
 
   if (!isAdkInitialized()) {

--- a/packages/adt-cli/src/lib/utils/adt-client-v2.ts
+++ b/packages/adt-cli/src/lib/utils/adt-client-v2.ts
@@ -555,8 +555,7 @@ export async function getAdtClientV2Safe(
     return testOverride;
   }
 
-  // Resolve the headers timeout before any auth/refresh work so an invalid
-  // value fails fast instead of after a potentially network-bound refresh.
+  // Fail fast on an invalid timeout before any auth/refresh work.
   const headersTimeoutMs = resolveAdtHeadersTimeoutMs();
 
   const ctx = getCliContext();

--- a/packages/adt-cli/src/lib/utils/adt-client-v2.ts
+++ b/packages/adt-cli/src/lib/utils/adt-client-v2.ts
@@ -324,6 +324,10 @@ export async function getAdtClientV2(
     return testOverride;
   }
 
+  // Resolve the headers timeout before any auth/refresh work so an invalid
+  // value fails fast instead of after a potentially network-bound refresh.
+  const headersTimeoutMs = resolveAdtHeadersTimeoutMs();
+
   // Merge with global CLI context (explicit options take precedence)
   const ctx = getCliContext();
   const effectiveOptions = {
@@ -511,7 +515,7 @@ export async function getAdtClientV2(
     logger,
     plugins,
     onSessionExpired,
-    headersTimeoutMs: resolveAdtHeadersTimeoutMs(),
+    headersTimeoutMs,
   });
 
   // Initialize ADK global context if not already done
@@ -550,6 +554,10 @@ export async function getAdtClientV2Safe(
   if (testOverride) {
     return testOverride;
   }
+
+  // Resolve the headers timeout before any auth/refresh work so an invalid
+  // value fails fast instead of after a potentially network-bound refresh.
+  const headersTimeoutMs = resolveAdtHeadersTimeoutMs();
 
   const ctx = getCliContext();
   const effectiveOptions = {
@@ -721,7 +729,7 @@ export async function getAdtClientV2Safe(
     logger,
     plugins,
     onSessionExpired,
-    headersTimeoutMs: resolveAdtHeadersTimeoutMs(),
+    headersTimeoutMs,
   });
 
   if (!isAdkInitialized()) {

--- a/packages/adt-cli/src/lib/utils/adt-http-options.test.ts
+++ b/packages/adt-cli/src/lib/utils/adt-http-options.test.ts
@@ -12,6 +12,12 @@ describe('resolveAdtHeadersTimeoutMs', () => {
     expect(resolveAdtHeadersTimeoutMs({})).toBeUndefined();
   });
 
+  it('treats an empty string as unset (equivalent to leaving it unset)', () => {
+    expect(
+      resolveAdtHeadersTimeoutMs({ ADT_HEADERS_TIMEOUT_MS: '' }),
+    ).toBeUndefined();
+  });
+
   it.each(['0', '-1', '1.5', 'invalid'])(
     'rejects invalid timeout %s',
     (value) => {

--- a/packages/adt-cli/src/lib/utils/adt-http-options.test.ts
+++ b/packages/adt-cli/src/lib/utils/adt-http-options.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAdtHeadersTimeoutMs } from './adt-http-options';
+
+describe('resolveAdtHeadersTimeoutMs', () => {
+  it('returns the configured positive integer timeout', () => {
+    expect(
+      resolveAdtHeadersTimeoutMs({ ADT_HEADERS_TIMEOUT_MS: '900000' }),
+    ).toBe(900_000);
+  });
+
+  it('leaves the native client timeout unchanged when unset', () => {
+    expect(resolveAdtHeadersTimeoutMs({})).toBeUndefined();
+  });
+
+  it.each(['0', '-1', '1.5', 'invalid'])(
+    'rejects invalid timeout %s',
+    (value) => {
+      expect(() =>
+        resolveAdtHeadersTimeoutMs({ ADT_HEADERS_TIMEOUT_MS: value }),
+      ).toThrow('ADT_HEADERS_TIMEOUT_MS must be a positive integer');
+    },
+  );
+});

--- a/packages/adt-cli/src/lib/utils/adt-http-options.ts
+++ b/packages/adt-cli/src/lib/utils/adt-http-options.ts
@@ -1,0 +1,17 @@
+const HEADERS_TIMEOUT_ENV = 'ADT_HEADERS_TIMEOUT_MS';
+
+export function resolveAdtHeadersTimeoutMs(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): number | undefined {
+  const raw = env[HEADERS_TIMEOUT_ENV];
+  if (raw === undefined || raw === '') return undefined;
+  if (!/^\d+$/.test(raw)) {
+    throw new RangeError(`${HEADERS_TIMEOUT_ENV} must be a positive integer`);
+  }
+
+  const timeoutMs = Number(raw);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError(`${HEADERS_TIMEOUT_ENV} must be a positive integer`);
+  }
+  return timeoutMs;
+}

--- a/packages/adt-client/README.md
+++ b/packages/adt-client/README.md
@@ -89,6 +89,8 @@ createAdtClient(config: AdtConnectionConfig): AdtClient
 - `password` - SAP password
 - `client` - SAP client (optional, e.g., `'100'`)
 - `language` - SAP language (optional, e.g., `'EN'`)
+- `headersTimeoutMs` - response-header timeout for long-running SAP requests
+  (optional; otherwise the native HTTP client default applies)
 
 ### Class Operations
 

--- a/packages/adt-client/package.json
+++ b/packages/adt-client/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@abapify/logger": "0.4.1",
     "@abapify/adt-contracts": "0.4.1",
-    "@abapify/adt-schemas": "0.4.1"
+    "@abapify/adt-schemas": "0.4.1",
+    "undici": "^8.10.0"
   },
   "repository": {
     "type": "git",

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -185,6 +185,13 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       ? undefined
       : new Agent({ headersTimeout: headersTimeoutMs });
 
+  /** Merge the optional Undici dispatcher into a fetch RequestInit. */
+  function withDispatcher<T extends RequestInit>(
+    init: T,
+  ): T & { dispatcher?: Dispatcher } {
+    return dispatcher ? { ...init, dispatcher } : init;
+  }
+
   // Determine auth method
   const isSamlAuth = !!cookieHeader;
 
@@ -386,13 +393,15 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
           'Request headers (names only): ' + JSON.stringify(headerNames),
         );
       }
-      const response = await fetch(url.toString(), {
-        method: options.method,
-        headers,
-        body: requestBody,
-        signal: executionSignal,
-        ...(dispatcher ? { dispatcher } : {}),
-      } as RequestInit & { dispatcher?: Dispatcher });
+      const response = await fetch(
+        url.toString(),
+        withDispatcher({
+          method: options.method,
+          headers,
+          body: requestBody,
+          signal: executionSignal,
+        }),
+      );
 
       // Process response for session management (cookies, CSRF, ETags)
       sessionManager.processResponse(response, url.pathname);
@@ -570,12 +579,14 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       const { abortController, dispose } = executionAbortController();
       try {
         // nosemgrep
-        const response = await fetch(url, {
-          method: 'GET',
-          headers,
-          signal: abortController.signal,
-          ...(dispatcher ? { dispatcher } : {}),
-        } as RequestInit & { dispatcher?: Dispatcher });
+        const response = await fetch(
+          url,
+          withDispatcher({
+            method: 'GET',
+            headers,
+            signal: abortController.signal,
+          }),
+        );
         sessionManager.processResponse(response, url.pathname);
 
         const text = await readResponseTextBounded(

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -11,6 +11,7 @@ import type { ResponsePlugin, ResponseContext } from './plugins/types';
 import { SessionManager } from './utils/session';
 import { createAdtError } from './errors';
 import { activeAdtAbortSignal } from './cancellation';
+import { Agent, type Dispatcher } from 'undici';
 
 // Re-export HttpAdapter type for consumers
 /**
@@ -176,7 +177,13 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
     logger,
     plugins = [],
     onSessionExpired,
+    headersTimeoutMs,
   } = config;
+
+  const dispatcher =
+    headersTimeoutMs === undefined
+      ? undefined
+      : new Agent({ headersTimeout: headersTimeoutMs });
 
   // Determine auth method
   const isSamlAuth = !!cookieHeader;
@@ -384,7 +391,8 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
         headers,
         body: requestBody,
         signal: executionSignal,
-      });
+        ...(dispatcher ? { dispatcher } : {}),
+      } as RequestInit & { dispatcher?: Dispatcher });
 
       // Process response for session management (cookies, CSRF, ETags)
       sessionManager.processResponse(response, url.pathname);
@@ -566,7 +574,8 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
           method: 'GET',
           headers,
           signal: abortController.signal,
-        });
+          ...(dispatcher ? { dispatcher } : {}),
+        } as RequestInit & { dispatcher?: Dispatcher });
         sessionManager.processResponse(response, url.pathname);
 
         const text = await readResponseTextBounded(

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -594,7 +594,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       const { abortController, dispose } = executionAbortController();
       try {
         const response = await fetch(
-          url.toString(),
+          url.toString(), // nosemgrep — origin validated by resolveAdtUrl above
           withDispatcher({
             method: 'GET',
             headers,

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -579,8 +579,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       const { abortController, dispose } = executionAbortController();
       try {
         const response = await fetch(
-          // nosemgrep: user-controlled URL is the ADT base URL + object path
-          url,
+          url, // nosemgrep: ADT base URL + object path, not user-controlled
           withDispatcher({
             method: 'GET',
             headers,

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -594,7 +594,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       const { abortController, dispose } = executionAbortController();
       try {
         const response = await fetch(
-          url,
+          url.toString(),
           withDispatcher({
             method: 'GET',
             headers,

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -192,6 +192,21 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
     return dispatcher ? { ...init, dispatcher } : init;
   }
 
+  /**
+   * Resolve `options.url` against the configured `baseUrl` and reject
+   * absolute URLs that would send credentials to a different origin.
+   */
+  function resolveAdtUrl(requestUrl: string): URL {
+    const resolved = new URL(requestUrl, baseUrl);
+    const baseOrigin = new URL(baseUrl).origin;
+    if (resolved.origin !== baseOrigin) {
+      throw new RangeError(
+        `Refusing to fetch ${resolved.origin} — ADT requests must target the configured base origin ${baseOrigin}`,
+      );
+    }
+    return resolved;
+  }
+
   // Determine auth method
   const isSamlAuth = !!cookieHeader;
 
@@ -228,8 +243,8 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
         options.bodySchema ? 'present' : 'undefined',
       );
 
-      // Build full URL
-      const url = new URL(options.url, baseUrl);
+      // Build full URL (validated against the configured base origin)
+      const url = resolveAdtUrl(options.url);
 
       // Add query parameters
       if (options.query) {
@@ -565,7 +580,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
         throw new RangeError('maxBytes must be a non-negative safe integer.');
       }
 
-      const url = new URL(options.url, baseUrl);
+      const url = resolveAdtUrl(options.url);
       if (client) url.searchParams.append('sap-client', client);
       if (language) url.searchParams.append('sap-language', language);
 
@@ -579,7 +594,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       const { abortController, dispose } = executionAbortController();
       try {
         const response = await fetch(
-          url, // nosemgrep: ADT base URL + object path, not user-controlled
+          url,
           withDispatcher({
             method: 'GET',
             headers,

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -578,8 +578,8 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
 
       const { abortController, dispose } = executionAbortController();
       try {
-        // nosemgrep
         const response = await fetch(
+          // nosemgrep: user-controlled URL is the ADT base URL + object path
           url,
           withDispatcher({
             method: 'GET',

--- a/packages/adt-client/src/types.ts
+++ b/packages/adt-client/src/types.ts
@@ -15,6 +15,8 @@ export interface AdtConnectionConfig {
   client?: string;
   language?: string;
   logger?: Logger;
+  /** Override Undici's response-header timeout for long-running SAP requests. */
+  headersTimeoutMs?: number;
 }
 
 // Note: Class/Interface types are available from adt-schemas via InferXsd

--- a/packages/adt-client/tests/adapter-headers-timeout.test.ts
+++ b/packages/adt-client/tests/adapter-headers-timeout.test.ts
@@ -47,4 +47,22 @@ describe('ADT response header timeout', () => {
       dispatcher: expect.anything(),
     });
   });
+
+  it('rejects absolute URLs that target a different origin', async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    const adapter = createAdtAdapter({
+      baseUrl: 'https://sap.example.test',
+      username: 'test',
+      password: 'test',
+    } as AdtAdapterConfig);
+
+    await expect(
+      adapter.request({
+        method: 'GET',
+        url: 'https://evil.example.test/sap/bc/adt/abapunit/testruns',
+      }),
+    ).rejects.toThrow(/ADT requests must target the configured base origin/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/adt-client/tests/adapter-headers-timeout.test.ts
+++ b/packages/adt-client/tests/adapter-headers-timeout.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const agentConstructions = vi.hoisted(
+  () => [] as Array<Record<string, unknown>>,
+);
+
+vi.mock('undici', () => ({
+  Agent: class {
+    constructor(options: Record<string, unknown>) {
+      agentConstructions.push(options);
+    }
+  },
+}));
+
+import { createAdtAdapter, type AdtAdapterConfig } from '../src/adapter';
+
+describe('ADT response header timeout', () => {
+  afterEach(() => {
+    agentConstructions.length = 0;
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the configured timeout for long-running SAP requests', async () => {
+    const fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response('<result />', {
+          headers: { 'content-type': 'application/xml' },
+        }),
+      ),
+    );
+    vi.stubGlobal('fetch', fetch);
+    const config = {
+      baseUrl: 'https://sap.example.test',
+      username: 'test',
+      password: 'test',
+      headersTimeoutMs: 900_000,
+    } as AdtAdapterConfig & { headersTimeoutMs: number };
+    const adapter = createAdtAdapter(config);
+
+    await adapter.request({
+      method: 'GET',
+      url: '/sap/bc/adt/abapunit/testruns',
+    });
+
+    expect(agentConstructions).toEqual([{ headersTimeout: 900_000 }]);
+    expect(fetch.mock.calls[0]?.[1]).toMatchObject({
+      dispatcher: expect.anything(),
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- add an optional `headersTimeoutMs` connection setting for SAP requests that take longer than Undici's default response-header timeout
- expose the setting to the CLI as `ADT_HEADERS_TIMEOUT_MS`
- keep the native timeout unchanged unless the caller explicitly opts in

## Why

A transport-scoped ABAP Unit run against a live SAP system reached the server successfully but did not return response headers within 300 seconds. Node aborted the request with `UND_ERR_HEADERS_TIMEOUT`, so the caller could not receive the JUnit or coverage result even though authentication and SAP connectivity were working.

This change lets CI choose a bounded timeout appropriate for long-running AUnit requests without changing behavior for other users.

## Verification

- added an adapter unit test proving the configured timeout is used by the Undici dispatcher
- added CLI parsing tests covering configured, unset, and invalid values
- `nx test @abapify/adt-client`
- focused `adt-cli` timeout test
- lint for `@abapify/adt-client` and `adt-cli`
- fresh builds for `@abapify/adt-client` and `adt-cli`
- Prettier and `git diff --check`

The repository-wide typecheck currently reports pre-existing errors in `adt-contracts`, `adt-plugin-abapgit`, and existing CLI command types; no reported error is in this change.


___

## **CodeAnt-AI Description**
Support long-running SAP requests without changing the default timeout

### What Changed
- SAP clients can set a custom response-header timeout for operations that take longer than the native HTTP limit
- The CLI reads `ADT_HEADERS_TIMEOUT_MS` and applies it to SAP requests
- The native timeout remains unchanged when the setting is omitted
- Invalid, zero, fractional, or unsafe timeout values are rejected before a request is sent
- Client and CLI documentation now explain how to configure the timeout

### Impact
`✅ Fewer timeouts during long-running AUnit runs`
`✅ Configurable SAP request duration in CI`
`✅ Clear validation errors before requests start`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports long-running SAP requests and enforces same-origin ADT calls. Previously, requests > ~300s failed with UND_ERR_HEADERS_TIMEOUT and absolute URLs could send credentials cross-origin; now callers can opt into a longer response‑header timeout and the client rejects ADT requests that resolve to a different origin.

- `@abapify/adt-client`: Add `headersTimeoutMs` to `AdtConnectionConfig`; create an `undici` `Agent({ headersTimeout })` and attach via dispatcher; extract a `withDispatcher` helper; enforce base-origin resolution and throw on cross-origin absolute URLs; use `url.toString()` at both fetch sites; add an inline `// nosemgrep` to suppress a Codacy SSRP false positive on the origin-validated fetch; depend on `undici` `^8.10.0`.
- `adt-cli`: Read `ADT_HEADERS_TIMEOUT_MS` and resolve it before any auth/session refresh to fail fast; treat an empty value as unset; reject invalid, zero, fractional, or non-numeric values before sending.
- Tests/docs: Add adapter tests for the timeout and base-origin enforcement (including absolute URL rejection) and CLI parsing tests (including empty-string-as-unset). Update `@abapify/adt-client` and `adt-cli` READMEs with usage examples.
- Migration: Default behavior is unchanged when the timeout is unset. Ensure all ADT request URLs are relative or same-origin; cross-origin absolute URLs now fail early with a RangeError.

<sup>Written for commit 011313fc08beffff4c256bb08510a1a70d1f87d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional response-header timeout setting for long-running SAP operations.
  * CLI users can configure the timeout with `ADT_HEADERS_TIMEOUT_MS`.
  * The setting accepts positive whole numbers; invalid, zero, negative, fractional, or non-numeric values are rejected before requests are sent.
  * Unset or empty configuration preserves the native default behavior.

* **Documentation**
  * Documented timeout configuration, defaults, validation rules, and usage for the CLI and client library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->