### PR TITLE
fix(client): pair timeout agent with undici fetch

### DIFF
--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -205,6 +205,19 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
   }
 
   /**
+   * Route a session-manager request through the same paired Undici
+   * fetch/dispatcher used for the final adapter request, so the
+   * configured headersTimeout applies to the entire write flow
+   * (CSRF handshake included), not just the last hop.
+   */
+  async function sessionFetch(
+    input: string | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    return requestFetch(input.toString(), withDispatcher(init ?? {}));
+  }
+
+  /**
    * Resolve `options.url` against the configured `baseUrl` and reject
    * absolute URLs that would send credentials to a different origin.
    */
@@ -233,7 +246,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       : `Basic ${Buffer.from(basicCredentials).toString('base64')}`);
 
   // Create session manager for stateful sessions
-  const sessionManager = new SessionManager(logger);
+  const sessionManager = new SessionManager(logger, sessionFetch);
 
   // Inject SAML cookie if provided
   if (cookieHeader) {

--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -11,7 +11,7 @@ import type { ResponsePlugin, ResponseContext } from './plugins/types';
 import { SessionManager } from './utils/session';
 import { createAdtError } from './errors';
 import { activeAdtAbortSignal } from './cancellation';
-import { Agent, type Dispatcher } from 'undici';
+import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
 
 // Re-export HttpAdapter type for consumers
 /**
@@ -190,6 +190,18 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
     init: T,
   ): T & { dispatcher?: Dispatcher } {
     return dispatcher ? { ...init, dispatcher } : init;
+  }
+
+  /** Keep a configured Agent paired with the Undici fetch ABI that created it. */
+  async function requestFetch(
+    input: string,
+    init: RequestInit & { dispatcher?: Dispatcher },
+  ): Promise<Response> {
+    if (!dispatcher) return globalThis.fetch(input, init);
+    return (await undiciFetch(
+      input,
+      init as Parameters<typeof undiciFetch>[1],
+    )) as unknown as Response;
   }
 
   /**
@@ -408,7 +420,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
           'Request headers (names only): ' + JSON.stringify(headerNames),
         );
       }
-      const response = await fetch(
+      const response = await requestFetch(
         url.toString(),
         withDispatcher({
           method: options.method,
@@ -593,7 +605,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
 
       const { abortController, dispose } = executionAbortController();
       try {
-        const response = await fetch(
+        const response = await requestFetch(
           url.toString(), // nosemgrep — origin validated by resolveAdtUrl above
           withDispatcher({
             method: 'GET',

--- a/packages/adt-client/src/utils/session.ts
+++ b/packages/adt-client/src/utils/session.ts
@@ -8,6 +8,17 @@
 import type { Logger } from '@abapify/logger';
 
 /**
+ * Fetch function injected into SessionManager so the adapter can route
+ * CSRF handshake requests through the same Undici dispatcher (and
+ * headersTimeout) used for the final adapter request. Defaults to the
+ * global fetch when no dispatcher is configured.
+ */
+export type SessionFetchFn = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
  * Cookie Store - Manages HTTP cookies for stateful sessions
  */
 export class CookieStore {
@@ -288,7 +299,10 @@ export class SessionManager {
   private readonly etagManager = new ETagManager();
   private securitySessionActive = false;
 
-  constructor(private readonly logger?: Logger) {}
+  constructor(
+    private readonly logger?: Logger,
+    private readonly fetchFn: SessionFetchFn = globalThis.fetch,
+  ) {}
 
   /**
    * Process response to update session state
@@ -572,7 +586,7 @@ export class SessionManager {
   ): Promise<string | undefined> {
     this.logger?.debug('Session: Creating security session');
     // nosemgrep
-    const response = await fetch(sessionsUrl, {
+    const response = await this.fetchFn(sessionsUrl, {
       method: 'GET',
       headers: {
         ...this.buildSessionHeaders(authHeader),
@@ -602,7 +616,7 @@ export class SessionManager {
   ): Promise<boolean> {
     this.logger?.debug('Session: Fetching CSRF token');
     // nosemgrep
-    const response = await fetch(sessionsUrl, {
+    const response = await this.fetchFn(sessionsUrl, {
       method: 'GET',
       headers: {
         ...this.buildSessionHeaders(authHeader),
@@ -659,7 +673,7 @@ export class SessionManager {
     try {
       this.logger?.debug(`Session: Deleting security session ${sessionPath}`);
       // nosemgrep
-      await fetch(deleteUrl, {
+      await this.fetchFn(deleteUrl, {
         method: 'DELETE',
         headers: {
           ...this.buildSessionHeaders(authHeader),
@@ -695,7 +709,7 @@ export class SessionManager {
         'Session: Fetching CSRF token for security session cleanup',
       );
       // nosemgrep
-      const response = await fetch(sessionsUrl, {
+      const response = await this.fetchFn(sessionsUrl, {
         method: 'GET',
         headers: {
           ...this.buildSessionHeaders(authHeader),

--- a/packages/adt-client/tests/adapter-headers-timeout.test.ts
+++ b/packages/adt-client/tests/adapter-headers-timeout.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const agentConstructions = vi.hoisted(
   () => [] as Array<Record<string, unknown>>,
 );
+const undiciFetch = vi.hoisted(() => vi.fn());
 
 vi.mock('undici', () => ({
   Agent: class {
@@ -10,6 +11,7 @@ vi.mock('undici', () => ({
       agentConstructions.push(options);
     }
   },
+  fetch: undiciFetch,
 }));
 
 import { createAdtAdapter, type AdtAdapterConfig } from '../src/adapter';
@@ -17,18 +19,18 @@ import { createAdtAdapter, type AdtAdapterConfig } from '../src/adapter';
 describe('ADT response header timeout', () => {
   afterEach(() => {
     agentConstructions.length = 0;
+    undiciFetch.mockReset();
     vi.unstubAllGlobals();
   });
 
-  it('uses the configured timeout for long-running SAP requests', async () => {
-    const fetch = vi.fn().mockImplementation(() =>
-      Promise.resolve(
-        new Response('<result />', {
-          headers: { 'content-type': 'application/xml' },
-        }),
-      ),
+  it('uses the matching Undici fetch implementation with the configured Agent', async () => {
+    undiciFetch.mockResolvedValue(
+      new Response('<result />', {
+        headers: { 'content-type': 'application/xml' },
+      }),
     );
-    vi.stubGlobal('fetch', fetch);
+    const nativeFetch = vi.fn();
+    vi.stubGlobal('fetch', nativeFetch);
     const config = {
       baseUrl: 'https://sap.example.test',
       username: 'test',
@@ -43,9 +45,10 @@ describe('ADT response header timeout', () => {
     });
 
     expect(agentConstructions).toEqual([{ headersTimeout: 900_000 }]);
-    expect(fetch.mock.calls[0]?.[1]).toMatchObject({
+    expect(undiciFetch.mock.calls[0]?.[1]).toMatchObject({
       dispatcher: expect.anything(),
     });
+    expect(nativeFetch).not.toHaveBeenCalled();
   });
 
   it('rejects absolute URLs that target a different origin', async () => {

--- a/packages/adt-client/tests/adapter-headers-timeout.test.ts
+++ b/packages/adt-client/tests/adapter-headers-timeout.test.ts
@@ -68,4 +68,70 @@ describe('ADT response header timeout', () => {
     ).rejects.toThrow(/ADT requests must target the configured base origin/);
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it('routes the CSRF handshake through the paired Undici fetch with the configured dispatcher', async () => {
+    const nativeFetch = vi.fn();
+    vi.stubGlobal('fetch', nativeFetch);
+
+    undiciFetch.mockImplementation(async (_input: unknown, init?: any) => {
+      const headers = init?.headers ?? {};
+      const secSession = headers['x-sap-security-session'];
+      const csrfHeader = headers['x-csrf-token'];
+      const method = init?.method ?? 'GET';
+
+      // Step 1: create security session
+      if (secSession === 'create') {
+        return new Response(
+          '<atom:entry xmlns:atom="http://www.w3.org/2005/Atom">' +
+            '<atom:link href="/sap/bc/adt/core/http/sessions/TEST123" ' +
+            'rel="http://www.sap.com/adt/categories/core/http/sessions/securitysession"/>' +
+            '</atom:entry>',
+          {
+            status: 200,
+            headers: {
+              'content-type':
+                'application/vnd.sap.adt.core.http.session.v3+xml',
+            },
+          },
+        );
+      }
+      // Step 2: fetch CSRF token
+      if (secSession === 'use' && csrfHeader === 'Fetch') {
+        return new Response('', {
+          status: 200,
+          headers: { 'x-csrf-token': 'csrf-token-value' },
+        });
+      }
+      // Step 3: delete security session
+      if (method === 'DELETE') {
+        return new Response('', { status: 200 });
+      }
+      // Step 4: the actual POST request
+      return new Response('<result />', {
+        status: 200,
+        headers: { 'content-type': 'application/xml' },
+      });
+    });
+
+    const adapter = createAdtAdapter({
+      baseUrl: 'https://sap.example.test',
+      username: 'test',
+      password: 'test',
+      headersTimeoutMs: 900_000,
+    } as AdtAdapterConfig & { headersTimeoutMs: number });
+
+    await adapter.request({
+      method: 'POST',
+      url: '/sap/bc/adt/abapunit/testruns',
+      body: '<test/>',
+    });
+
+    // Every undiciFetch call (CSRF handshake + final POST) must carry the dispatcher
+    for (const call of undiciFetch.mock.calls) {
+      expect(call[1]).toMatchObject({ dispatcher: expect.anything() });
+    }
+    // At least 4 calls: create, fetch CSRF, delete session, final POST
+    expect(undiciFetch.mock.calls.length).toBeGreaterThanOrEqual(4);
+    expect(nativeFetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

- pair a configured Undici Agent with the matching undici.fetch implementation
- keep native global fetch unchanged when no headers timeout is configured
- add a regression assertion that timeout-enabled requests never cross the fetch/Agent ABI boundary

## Root cause

Node 24 built-in fetch and undici 8 use different request-handler ABIs. Passing an undici 8 Agent to Node 24 global fetch fails with UND_ERR_INVALID_ARG: invalid onRequestStart method.

Observed live in S0D job: https://gitlab.com/booking-com/finsys-devops/s0d/-/jobs/16049262832

## Verification

- NX_NO_CLOUD=true bunx nx run @abapify/adt-client:test --skip-nx-cache
- NX_NO_CLOUD=true bunx nx run @abapify/adt-client:lint --skip-nx-cache
- NX_NO_CLOUD=true bunx nx run @abapify/adt-client:build --skip-nx-cache
- local Node 24 HTTP request through the built ADT adapter: node24-adapter-ok

The workspace typecheck still reports the pre-existing unused describe/it imports in packages/adt-contracts/tests/contracts/coverage.test.ts; no adt-client type errors remain.


___

## **CodeAnt-AI Description**
Prevent timeout-enabled ADT requests from failing on Node 24

### What Changed
- Requests with a configured response-header timeout now use the matching Undici fetch implementation with its timeout agent
- Requests without a timeout continue using the native fetch implementation
- Added coverage to ensure the native fetch is not used with an Undici agent

### Impact
`✅ Fewer Node 24 request failures`
`✅ Reliable long-running SAP requests`
`✅ Native fetch behavior preserved by default`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure timeout-enabled ADT requests use `undici.fetch` with the configured `Agent`, and route the CSRF handshake through the same paired dispatcher so headers timeouts apply end-to-end. Previously, Node 24 `globalThis.fetch` with an `undici` 8 `Agent` failed (UND_ERR_INVALID_ARG), and the CSRF handshake ran on native fetch without the timeout.

- Adds `requestFetch` to select `undici.fetch` when a dispatcher/`Agent` is configured; otherwise uses `globalThis.fetch`.
- Injects `sessionFetch` into `SessionManager` so security session create/fetch/delete requests use the paired `undici.fetch` and respect `headersTimeoutMs`.
- Extends tests to assert timeout-enabled requests and the CSRF handshake use `undici.fetch` with a dispatcher; default requests continue on `globalThis.fetch`.

<sup>Written for commit 9e184fb91c39b60be11eb1d1eb44ead2f7a4c12c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when a custom network dispatcher is configured.
  * Ensured standard, bounded-text, and security-session requests consistently use the configured dispatcher.
  * Improved CSRF-protected POST requests by applying the configured network settings throughout the session handshake.
  * Preserved existing behavior for requests without a custom dispatcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->