### PR TITLE
fix(aunit): send SAP coverage query bodies

### DIFF
--- a/packages/adt-aunit/src/commands/aunit.ts
+++ b/packages/adt-aunit/src/commands/aunit.ts
@@ -69,6 +69,32 @@ interface AdtClient {
   };
 }
 
+type CoverageClient = NonNullable<
+  AdtClient['adt']['runtime']
+>['traces']['coverage'];
+
+async function fetchCoverageData(
+  coverage: CoverageClient,
+  measurementId: string,
+  targetUris: string[],
+): Promise<{
+  measurements: AcoverageResultSchema;
+  statements: AcoverageStatementsSchema | undefined;
+}> {
+  const measurements = await coverage.measurements.post(
+    measurementId,
+    buildCoverageQuery(targetUris),
+  );
+  const statementUris = extractCoverageStatementUris(measurements);
+  if (statementUris.length === 0)
+    return { measurements, statements: undefined };
+  const statements = await coverage.statements.post(
+    measurementId,
+    buildStatementsBulkRequest(statementUris),
+  );
+  return { measurements, statements };
+}
+
 // Request body shape (matches aunitRun schema)
 interface RunConfigurationBody {
   runConfiguration: {
@@ -643,18 +669,11 @@ export const aunitCommand: CliCommandPlugin = {
       } else {
         try {
           const cov = client.adt.runtime.traces.coverage;
-          const measurements = await cov.measurements.post(
+          const { measurements, statements } = await fetchCoverageData(
+            cov,
             measurementId,
-            buildCoverageQuery(targetUris),
+            targetUris,
           );
-          const statementUris = extractCoverageStatementUris(measurements);
-          const statements =
-            statementUris.length > 0
-              ? await cov.statements.post(
-                  measurementId,
-                  buildStatementsBulkRequest(statementUris),
-                )
-              : undefined;
           const format = options.coverageFormat ?? 'jacoco';
           const xml =
             format === 'sonar-generic'

--- a/packages/adt-aunit/src/commands/aunit.ts
+++ b/packages/adt-aunit/src/commands/aunit.ts
@@ -9,7 +9,12 @@
  */
 
 import type { CliCommandPlugin, CliContext } from '@abapify/adt-plugin';
-import { extractCoverageMeasurementId } from '@abapify/adt-contracts';
+import {
+  buildCoverageQuery,
+  buildStatementsBulkRequest,
+  extractCoverageMeasurementId,
+  extractCoverageStatementUris,
+} from '@abapify/adt-contracts';
 import {
   acoverageResult,
   acoverageStatements,
@@ -50,10 +55,13 @@ interface AdtClient {
       traces: {
         coverage: {
           measurements: {
-            post: (id: string) => Promise<AcoverageResultSchema>;
+            post: (id: string, body: string) => Promise<AcoverageResultSchema>;
           };
           statements: {
-            get: (id: string) => Promise<AcoverageStatementsSchema>;
+            post: (
+              id: string,
+              body: string,
+            ) => Promise<AcoverageStatementsSchema>;
           };
         };
       };
@@ -635,8 +643,18 @@ export const aunitCommand: CliCommandPlugin = {
       } else {
         try {
           const cov = client.adt.runtime.traces.coverage;
-          const measurements = await cov.measurements.post(measurementId);
-          const statements = await cov.statements.get(measurementId);
+          const measurements = await cov.measurements.post(
+            measurementId,
+            buildCoverageQuery(targetUris),
+          );
+          const statementUris = extractCoverageStatementUris(measurements);
+          const statements =
+            statementUris.length > 0
+              ? await cov.statements.post(
+                  measurementId,
+                  buildStatementsBulkRequest(statementUris),
+                )
+              : undefined;
           const format = options.coverageFormat ?? 'jacoco';
           const xml =
             format === 'sonar-generic'

--- a/packages/adt-aunit/src/formatters/jacoco.ts
+++ b/packages/adt-aunit/src/formatters/jacoco.ts
@@ -3,9 +3,9 @@
  *
  * Consumes parsed coverage data from the adt-contracts runtime endpoints:
  *
- *   measurements: client.adt.runtime.traces.coverage.measurements.post(id)
+ *   measurements: client.adt.runtime.traces.coverage.measurements.post(id, query)
  *                 → AcoverageResultSchema  (tree of DEVC → CLAS → methods)
- *   statements:   client.adt.runtime.traces.coverage.statements.get(id)
+ *   statements:   client.adt.runtime.traces.coverage.statements.post(id, bulkRequest)
  *                 → AcoverageStatementsSchema (per-method line hits/misses)
  *
  * Emits JaCoCo 1.1 XML:

--- a/packages/adt-cli/tests/e2e/parity.coverage.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.coverage.test.ts
@@ -40,6 +40,27 @@ describe('CLI + MCP parity (aunit coverage)', () => {
     if (harness) await harness.stop();
   });
 
+  it('mock coverage endpoints reject root-only XML bodies', async () => {
+    const baseUrl = harness.connection.baseUrl;
+    const measurement = await fetch(
+      `${baseUrl}/sap/bc/adt/runtime/traces/coverage/measurements/ABC`,
+      {
+        method: 'POST',
+        body: '<cov:query xmlns:cov="http://www.sap.com/adt/cov"/>',
+      },
+    );
+    const statements = await fetch(
+      `${baseUrl}/sap/bc/adt/runtime/traces/coverage/results/ABC/statements`,
+      {
+        method: 'POST',
+        body: '<cov:statementsBulkRequest xmlns:cov="http://www.sap.com/adt/cov"/>',
+      },
+    );
+
+    expect(measurement.status).toBe(400);
+    expect(statements.status).toBe(400);
+  });
+
   it('CLI aunit --coverage --coverage-format jacoco emits JaCoCo XML', async () => {
     const lines: string[] = [];
     const ctx: CliContext = {

--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/index.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/index.ts
@@ -11,6 +11,12 @@ import { statements, type StatementsContract } from './statements';
 
 export { measurements } from './measurements';
 export { statements } from './statements';
+export {
+  buildCoverageQuery,
+  buildStatementsBulkRequest,
+  coverageXmlBody,
+  extractCoverageStatementUris,
+} from './request';
 export type { MeasurementsContract } from './measurements';
 export type { StatementsContract } from './statements';
 

--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/measurements.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/measurements.ts
@@ -11,6 +11,7 @@
 
 import { http, contract } from '../../../../base';
 import { acoverageResult } from '../../../../schemas';
+import { coverageXmlBody } from './request';
 
 const SCOV_CONTENT_TYPE = 'application/xml+scov';
 
@@ -27,10 +28,11 @@ export const measurements = contract({
       `/sap/bc/adt/runtime/traces/coverage/measurements/${identifier}`,
       {
         query: { withAdditionalTypeInfo: true },
+        body: coverageXmlBody,
         responses: { 200: acoverageResult },
         headers: {
           Accept: SCOV_CONTENT_TYPE,
-          'Content-Type': SCOV_CONTENT_TYPE,
+          'Content-Type': 'application/xml',
         },
       },
     ),

--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/request.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/request.ts
@@ -39,6 +39,44 @@ ${objectReferences}
 </cov:query>`;
 }
 
+function takeUnseenRecord(
+  value: unknown,
+  seenValues: Set<unknown>,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || seenValues.has(value)) return;
+  seenValues.add(value);
+  return value as Record<string, unknown>;
+}
+
+function takeStatementUri(
+  record: Record<string, unknown>,
+  seenUris: Set<string>,
+): string | undefined {
+  const { rel, href } = record;
+  if (
+    rel !== STATEMENTS_RELATION ||
+    typeof href !== 'string' ||
+    seenUris.has(href)
+  ) {
+    return;
+  }
+  seenUris.add(href);
+  return href;
+}
+
+function enqueueChildObjects(
+  record: Record<string, unknown>,
+  queue: unknown[],
+): void {
+  for (const child of Object.values(record)) {
+    if (Array.isArray(child)) {
+      queue.push(...child);
+      continue;
+    }
+    if (child && typeof child === 'object') queue.push(child);
+  }
+}
+
 export function extractCoverageStatementUris(value: unknown): string[] {
   const statementUris: string[] = [];
   const seenUris = new Set<string>();
@@ -46,26 +84,11 @@ export function extractCoverageStatementUris(value: unknown): string[] {
   const queue: unknown[] = [value];
 
   while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current || typeof current !== 'object' || seenValues.has(current)) {
-      continue;
-    }
-    seenValues.add(current);
-
-    const record = current as Record<string, unknown>;
-    if (
-      record.rel === STATEMENTS_RELATION &&
-      typeof record.href === 'string' &&
-      !seenUris.has(record.href)
-    ) {
-      seenUris.add(record.href);
-      statementUris.push(record.href);
-    }
-
-    for (const child of Object.values(record)) {
-      if (Array.isArray(child)) queue.push(...child);
-      else if (child && typeof child === 'object') queue.push(child);
-    }
+    const record = takeUnseenRecord(queue.shift(), seenValues);
+    if (!record) continue;
+    const statementUri = takeStatementUri(record, seenUris);
+    if (statementUri) statementUris.push(statementUri);
+    enqueueChildObjects(record, queue);
   }
 
   return statementUris;

--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/request.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/request.ts
@@ -1,0 +1,83 @@
+import type { Serializable } from '@abapify/speci/rest';
+
+const COVERAGE_NAMESPACE = 'http://www.sap.com/adt/cov';
+const ADT_CORE_NAMESPACE = 'http://www.sap.com/adt/core';
+const STATEMENTS_RELATION =
+  'http://www.sap.com/adt/relations/runtime/traces/coverage/results/statements';
+
+export const coverageXmlBody = {
+  parse: (value: unknown) => String(value),
+  build: (value: string) => value,
+  _infer: undefined as unknown as string,
+} satisfies Serializable<string>;
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+export function buildCoverageQuery(objectUris: string[]): string {
+  const objectReferences = objectUris
+    .map(
+      (uri) =>
+        `<adtcore:objectReference adtcore:uri="${escapeXmlAttribute(uri)}"/>`,
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<cov:query xmlns:cov="${COVERAGE_NAMESPACE}">
+<adtcore:objectSets xmlns:adtcore="${ADT_CORE_NAMESPACE}">
+<objectSet kind="inclusive">
+<adtcore:objectReferences>
+${objectReferences}
+</adtcore:objectReferences>
+</objectSet>
+</adtcore:objectSets>
+</cov:query>`;
+}
+
+export function extractCoverageStatementUris(value: unknown): string[] {
+  const statementUris: string[] = [];
+  const seenUris = new Set<string>();
+  const seenValues = new Set<unknown>();
+  const queue: unknown[] = [value];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== 'object' || seenValues.has(current)) {
+      continue;
+    }
+    seenValues.add(current);
+
+    const record = current as Record<string, unknown>;
+    if (
+      record.rel === STATEMENTS_RELATION &&
+      typeof record.href === 'string' &&
+      !seenUris.has(record.href)
+    ) {
+      seenUris.add(record.href);
+      statementUris.push(record.href);
+    }
+
+    for (const child of Object.values(record)) {
+      if (Array.isArray(child)) queue.push(...child);
+      else if (child && typeof child === 'object') queue.push(child);
+    }
+  }
+
+  return statementUris;
+}
+
+export function buildStatementsBulkRequest(statementUris: string[]): string {
+  const requests = statementUris
+    .map((uri) => `<statementsRequest get="${escapeXmlAttribute(uri)}"/>`)
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<cov:statementsBulkRequest xmlns:cov="${COVERAGE_NAMESPACE}">
+${requests}
+</cov:statementsBulkRequest>`;
+}

--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/statements.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/statements.ts
@@ -1,7 +1,7 @@
 /**
  * /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
  *
- * GET returns the cov:statementsBulkResponse with per-method statement
+ * POST returns the cov:statementsBulkResponse with per-method statement
  * / branch / procedure coverage details.
  *
  * Content-Type: application/xml+scov
@@ -9,20 +9,23 @@
 
 import { http, contract } from '../../../../base';
 import { acoverageStatements } from '../../../../schemas';
+import { coverageXmlBody } from './request';
 
 const SCOV_CONTENT_TYPE = 'application/xml+scov';
 
 export const statements = contract({
   /**
-   * GET /sap/bc/adt/runtime/traces/coverage/results/{identifier}/statements
+   * POST /sap/bc/adt/runtime/traces/coverage/results/{identifier}/statements
    */
-  get: (identifier: string) =>
-    http.get(
+  post: (identifier: string) =>
+    http.post(
       `/sap/bc/adt/runtime/traces/coverage/results/${identifier}/statements`,
       {
+        body: coverageXmlBody,
         responses: { 200: acoverageStatements },
         headers: {
           Accept: SCOV_CONTENT_TYPE,
+          'Content-Type': 'application/xml',
         },
       },
     ),

--- a/packages/adt-contracts/tests/contracts/coverage.test.ts
+++ b/packages/adt-contracts/tests/contracts/coverage.test.ts
@@ -5,7 +5,7 @@
  * coverage enabled:
  *
  *   POST /sap/bc/adt/runtime/traces/coverage/measurements/{id}?withAdditionalTypeInfo=true
- *   GET  /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
+ *   POST /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
  *
  * Fixtures are the real (sanitized) SAP responses from jfilak/sapcli.
  */
@@ -14,7 +14,11 @@ import { describe, it, expect } from 'vitest';
 import { fixtures } from '@abapify/adt-fixtures';
 import { acoverageResult, acoverageStatements } from '../../src/schemas';
 import {
+  buildCoverageQuery,
+  buildStatementsBulkRequest,
   coverageContract,
+  coverageXmlBody,
+  extractCoverageStatementUris,
   measurements,
   statements,
 } from '../../src/adt/runtime/traces/coverage';
@@ -37,9 +41,10 @@ class CoverageContractScenario extends ContractScenario {
       path: '/sap/bc/adt/runtime/traces/coverage/measurements/ABCDEF123',
       headers: {
         Accept: SCOV_CONTENT_TYPE,
-        'Content-Type': SCOV_CONTENT_TYPE,
+        'Content-Type': 'application/xml',
       },
       query: { withAdditionalTypeInfo: true },
+      body: { schema: coverageXmlBody },
       response: {
         status: 200,
         schema: acoverageResult,
@@ -47,11 +52,15 @@ class CoverageContractScenario extends ContractScenario {
       },
     },
     {
-      name: 'get statements',
-      contract: () => coverageContract.statements.get('ABCDEF123'),
-      method: 'GET',
+      name: 'post statements',
+      contract: () => coverageContract.statements.post('ABCDEF123'),
+      method: 'POST',
       path: '/sap/bc/adt/runtime/traces/coverage/results/ABCDEF123/statements',
-      headers: { Accept: SCOV_CONTENT_TYPE },
+      headers: {
+        Accept: SCOV_CONTENT_TYPE,
+        'Content-Type': 'application/xml',
+      },
+      body: { schema: coverageXmlBody },
       response: {
         status: 200,
         schema: acoverageStatements,
@@ -109,13 +118,13 @@ runTypedScenario(new MeasurementsTypedScenario());
 // 3. Typed scenario – statements bulk response
 // ─────────────────────────────────────────────────────────────
 class StatementsTypedScenario extends TypedContractScenario<
-  typeof statements.get
+  typeof statements.post
 > {
   readonly name = 'ABAP Coverage – statements (typed)';
-  readonly contract = statements.get;
+  readonly contract = statements.post;
   readonly fixture = fixtures.aunit.coverageStatements;
 
-  override getContractParams(): Parameters<typeof statements.get> {
+  override getContractParams(): Parameters<typeof statements.post> {
     return ['A6B627DB009F1EEB8FAA3720D9128253'];
   }
 
@@ -139,3 +148,36 @@ class StatementsTypedScenario extends TypedContractScenario<
 }
 
 runTypedScenario(new StatementsTypedScenario());
+
+describe('ABAP Coverage request bodies', () => {
+  it('builds the required cov:query around the tested object URIs', () => {
+    expect(buildCoverageQuery(['/sap/bc/adt/oo/classes/zcl_example&variant=1']))
+      .toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<cov:query xmlns:cov="http://www.sap.com/adt/cov">
+<adtcore:objectSets xmlns:adtcore="http://www.sap.com/adt/core">
+<objectSet kind="inclusive">
+<adtcore:objectReferences>
+<adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/zcl_example&amp;variant=1"/>
+</adtcore:objectReferences>
+</objectSet>
+</adtcore:objectSets>
+</cov:query>`);
+  });
+
+  it('extracts per-object statement links and builds the bulk request', async () => {
+    const measurementsXml = await fixtures.aunit.coverageMeasurements.load();
+    const parsed = acoverageResult.parse(measurementsXml);
+    const statementUris = extractCoverageStatementUris(parsed);
+
+    expect(statementUris.length).toBeGreaterThan(1);
+    expect(statementUris.every((uri) => uri.includes('/statements/'))).toBe(
+      true,
+    );
+    expect(buildStatementsBulkRequest(statementUris)).toContain(
+      '<cov:statementsBulkRequest xmlns:cov="http://www.sap.com/adt/cov">',
+    );
+    expect(buildStatementsBulkRequest(statementUris)).toContain(
+      `<statementsRequest get="${statementUris[0]}"/>`,
+    );
+  });
+});

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -580,6 +580,82 @@ function extractObjectUri(url: string): string {
   return url.split('?')[0];
 }
 
+function matchCoverageStatements(
+  method: string,
+  pathname: string,
+  requestBody: string,
+  f: LoadedFixtures,
+): RouteResult | undefined {
+  if (
+    method !== 'POST' ||
+    !/^\/sap\/bc\/adt\/runtime\/traces\/coverage\/results\/[^/]+\/statements/.test(
+      pathname,
+    )
+  ) {
+    return;
+  }
+  if (
+    !requestBody.includes('<cov:statementsBulkRequest') ||
+    !/<statementsRequest\b[^>]*\bget=(["'])[^"']+\1/.test(requestBody)
+  ) {
+    return {
+      status: 400,
+      body: 'Expected cov:statementsBulkRequest',
+      contentType: 'text/plain',
+    };
+  }
+  return {
+    status: 200,
+    body: f.coverageStatements,
+    contentType: 'application/xml+scov',
+  };
+}
+
+function matchCoverageMeasurements(
+  method: string,
+  pathname: string,
+  requestBody: string,
+  f: LoadedFixtures,
+): RouteResult | undefined {
+  if (
+    method !== 'POST' ||
+    !/^\/sap\/bc\/adt\/runtime\/traces\/coverage\/measurements\/[^/]+/.test(
+      pathname,
+    )
+  ) {
+    return;
+  }
+  if (
+    !requestBody.includes('<cov:query') ||
+    !/<adtcore:objectReference\b[^>]*\badtcore:uri=(["'])[^"']+\1/.test(
+      requestBody,
+    )
+  ) {
+    return {
+      status: 400,
+      body: 'Expected cov:query',
+      contentType: 'text/plain',
+    };
+  }
+  return {
+    status: 200,
+    body: f.coverageMeasurements,
+    contentType: 'application/xml+scov',
+  };
+}
+
+function matchCoverageRoute(
+  method: string,
+  pathname: string,
+  requestBody: string,
+  f: LoadedFixtures,
+): RouteResult | undefined {
+  return (
+    matchCoverageStatements(method, pathname, requestBody, f) ??
+    matchCoverageMeasurements(method, pathname, requestBody, f)
+  );
+}
+
 /**
  * Match a request method + url to a mock response.
  * Returns `undefined` if no route handles the request.
@@ -594,6 +670,8 @@ export function matchRoute(
 ): RouteResult | undefined {
   const m = method.toUpperCase();
   const pathname = url.split('?')[0];
+  const coverageRoute = matchCoverageRoute(m, pathname, requestBody, f);
+  if (coverageRoute) return coverageRoute;
 
   // ── ADT security session endpoints (strict-protocol aware) ─────────────
   // When called with x-sap-security-session: create, return an atom feed
@@ -1682,58 +1760,6 @@ export function matchRoute(
   // AUnit test run
   if (m === 'POST' && url.startsWith('/sap/bc/adt/abapunit/testruns')) {
     return { status: 200, body: f.aunit, contentType: 'application/json' };
-  }
-
-  // ABAP Coverage — statements bulk response
-  // POST /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
-  if (
-    m === 'POST' &&
-    /^\/sap\/bc\/adt\/runtime\/traces\/coverage\/results\/[^/]+\/statements/.test(
-      pathname,
-    )
-  ) {
-    if (
-      !requestBody.includes('<cov:statementsBulkRequest') ||
-      !/<statementsRequest\b[^>]*\bget=(["'])[^"']+\1/.test(requestBody)
-    ) {
-      return {
-        status: 400,
-        body: 'Expected cov:statementsBulkRequest',
-        contentType: 'text/plain',
-      };
-    }
-    return {
-      status: 200,
-      body: f.coverageStatements,
-      contentType: 'application/xml+scov',
-    };
-  }
-
-  // ABAP Coverage — measurement tree
-  // POST /sap/bc/adt/runtime/traces/coverage/measurements/{id}
-  if (
-    m === 'POST' &&
-    /^\/sap\/bc\/adt\/runtime\/traces\/coverage\/measurements\/[^/]+/.test(
-      pathname,
-    )
-  ) {
-    if (
-      !requestBody.includes('<cov:query') ||
-      !/<adtcore:objectReference\b[^>]*\badtcore:uri=(["'])[^"']+\1/.test(
-        requestBody,
-      )
-    ) {
-      return {
-        status: 400,
-        body: 'Expected cov:query',
-        contentType: 'text/plain',
-      };
-    }
-    return {
-      status: 200,
-      body: f.coverageMeasurements,
-      contentType: 'application/xml+scov',
-    };
   }
 
   // Function module source

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -1685,13 +1685,20 @@ export function matchRoute(
   }
 
   // ABAP Coverage — statements bulk response
-  // GET /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
+  // POST /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
   if (
-    m === 'GET' &&
+    m === 'POST' &&
     /^\/sap\/bc\/adt\/runtime\/traces\/coverage\/results\/[^/]+\/statements/.test(
       pathname,
     )
   ) {
+    if (!requestBody.includes('<cov:statementsBulkRequest')) {
+      return {
+        status: 400,
+        body: 'Expected cov:statementsBulkRequest',
+        contentType: 'text/plain',
+      };
+    }
     return {
       status: 200,
       body: f.coverageStatements,
@@ -1707,6 +1714,13 @@ export function matchRoute(
       pathname,
     )
   ) {
+    if (!requestBody.includes('<cov:query')) {
+      return {
+        status: 400,
+        body: 'Expected cov:query',
+        contentType: 'text/plain',
+      };
+    }
     return {
       status: 200,
       body: f.coverageMeasurements,

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -1692,7 +1692,10 @@ export function matchRoute(
       pathname,
     )
   ) {
-    if (!requestBody.includes('<cov:statementsBulkRequest')) {
+    if (
+      !requestBody.includes('<cov:statementsBulkRequest') ||
+      !/<statementsRequest\b[^>]*\bget=(["'])[^"']+\1/.test(requestBody)
+    ) {
       return {
         status: 400,
         body: 'Expected cov:statementsBulkRequest',
@@ -1714,7 +1717,12 @@ export function matchRoute(
       pathname,
     )
   ) {
-    if (!requestBody.includes('<cov:query')) {
+    if (
+      !requestBody.includes('<cov:query') ||
+      !/<adtcore:objectReference\b[^>]*\badtcore:uri=(["'])[^"']+\1/.test(
+        requestBody,
+      )
+    ) {
       return {
         status: 400,
         body: 'Expected cov:query',

--- a/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
+++ b/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
@@ -243,6 +243,33 @@ type CoverageFetchResult =
   | { kind: 'payload'; value: CoveragePayload }
   | { kind: 'limit'; value: SafeExecuteLimitResult };
 
+type CoverageClient = {
+  measurements: { post: (id: string, body: string) => Promise<unknown> };
+  statements: { post: (id: string, body: string) => Promise<unknown> };
+};
+
+async function fetchCoverageData(
+  coverage: CoverageClient,
+  measurementId: string,
+  targetUris: string[],
+): Promise<{
+  measurements: Parameters<typeof toJacocoXml>[0]['measurements'];
+  statements: Parameters<typeof toJacocoXml>[0]['statements'];
+}> {
+  const measurements = (await coverage.measurements.post(
+    measurementId,
+    buildCoverageQuery(targetUris),
+  )) as Parameters<typeof toJacocoXml>[0]['measurements'];
+  const statementUris = extractCoverageStatementUris(measurements);
+  if (statementUris.length === 0)
+    return { measurements, statements: undefined };
+  const statements = (await coverage.statements.post(
+    measurementId,
+    buildStatementsBulkRequest(statementUris),
+  )) as Parameters<typeof toJacocoXml>[0]['statements'];
+  return { measurements, statements };
+}
+
 async function fetchCoveragePayload(
   client: AdtClient,
   response: AunitResultData,
@@ -295,10 +322,11 @@ async function fetchCoveragePayload(
 
   const cov = runtime.traces.coverage;
   try {
-    const measurements = (await cov.measurements.post(
+    const { measurements, statements } = await fetchCoverageData(
+      cov,
       measurementId,
-      buildCoverageQuery(targetUris),
-    )) as Parameters<typeof toJacocoXml>[0]['measurements'];
+      targetUris,
+    );
     if (
       safePolicy?.check === 'coverage' &&
       coverageMeasurementCount(measurements.result) > safePolicy.maxMeasurements
@@ -308,14 +336,6 @@ async function fetchCoveragePayload(
         value: safeExecuteLimitResult('safe_execute_limit_exceeded'),
       };
     }
-    const statementUris = extractCoverageStatementUris(measurements);
-    const statements =
-      statementUris.length > 0
-        ? ((await cov.statements.post(
-            measurementId,
-            buildStatementsBulkRequest(statementUris),
-          )) as Parameters<typeof toJacocoXml>[0]['statements'])
-        : undefined;
     const xml =
       format === 'sonar-generic'
         ? toSonarGenericCoverageXml({ measurements, statements })

--- a/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
+++ b/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
@@ -22,7 +22,12 @@ import {
 } from './utils';
 import type { InferTypedSchema } from '@abapify/adt-schemas';
 import { aunitResult } from '@abapify/adt-schemas';
-import { extractCoverageMeasurementId } from '@abapify/adt-contracts';
+import {
+  buildCoverageQuery,
+  buildStatementsBulkRequest,
+  extractCoverageMeasurementId,
+  extractCoverageStatementUris,
+} from '@abapify/adt-contracts';
 import {
   toJacocoXml,
   toSonarGenericCoverageXml,
@@ -241,6 +246,7 @@ type CoverageFetchResult =
 async function fetchCoveragePayload(
   client: AdtClient,
   response: AunitResultData,
+  targetUris: string[],
   normalizedOptions: NormalizedUnitTestOptions,
   safePolicy: SafeExecutePolicy | undefined,
 ): Promise<CoverageFetchResult> {
@@ -251,8 +257,12 @@ async function fetchCoveragePayload(
         runtime?: {
           traces: {
             coverage: {
-              measurements: { post: (id: string) => Promise<unknown> };
-              statements: { get: (id: string) => Promise<unknown> };
+              measurements: {
+                post: (id: string, body: string) => Promise<unknown>;
+              };
+              statements: {
+                post: (id: string, body: string) => Promise<unknown>;
+              };
             };
           };
         };
@@ -287,6 +297,7 @@ async function fetchCoveragePayload(
   try {
     const measurements = (await cov.measurements.post(
       measurementId,
+      buildCoverageQuery(targetUris),
     )) as Parameters<typeof toJacocoXml>[0]['measurements'];
     if (
       safePolicy?.check === 'coverage' &&
@@ -297,9 +308,14 @@ async function fetchCoveragePayload(
         value: safeExecuteLimitResult('safe_execute_limit_exceeded'),
       };
     }
-    const statements = (await cov.statements.get(measurementId)) as Parameters<
-      typeof toJacocoXml
-    >[0]['statements'];
+    const statementUris = extractCoverageStatementUris(measurements);
+    const statements =
+      statementUris.length > 0
+        ? ((await cov.statements.post(
+            measurementId,
+            buildStatementsBulkRequest(statementUris),
+          )) as Parameters<typeof toJacocoXml>[0]['statements'])
+        : undefined;
     const xml =
       format === 'sonar-generic'
         ? toSonarGenericCoverageXml({ measurements, statements })
@@ -409,6 +425,7 @@ export function registerRunUnitTestsTool(
           const coverageResult = await fetchCoveragePayload(
             client,
             response as AunitResultData,
+            [objectUri],
             normalizedOptions,
             safePolicy,
           );

--- a/packages/adt-schemas/.xsd/custom/acoverageStatements.xsd
+++ b/packages/adt-schemas/.xsd/custom/acoverageStatements.xsd
@@ -3,7 +3,7 @@
   ABAP Coverage Statements Bulk Response Schema
 
   Response of:
-    GET /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
+    POST /sap/bc/adt/runtime/traces/coverage/results/{id}/statements
   Content-Type: application/xml+scov
 
   Sourced from jfilak/sapcli test fixtures (acoverage_statements).


### PR DESCRIPTION
## Problem

The AUnit coverage follow-up called the measurement endpoint with an empty POST body. SAP requires a `cov:query` containing the tested ADT object set and rejects an empty request with HTTP 400.

The statements endpoint was also modeled as a bodyless GET. The ADT protocol uses POST with a `cov:statementsBulkRequest` assembled from the per-object statement links in the measurement response.

The request shapes match the public sapcli implementation and fixtures:
https://github.com/jfilak/sapcli/blob/cb05a8ec2eef2e62a091d23cb1582e79417f5151/sap/adt/acoverage.py
https://github.com/jfilak/sapcli/blob/cb05a8ec2eef2e62a091d23cb1582e79417f5151/sap/adt/acoverage_statements.py

## Fix

- build and send the required `cov:query` using the exact AUnit target URIs
- extract per-object statements links from the measurement tree
- POST the matching `cov:statementsBulkRequest`
- apply the corrected flow to both CLI and MCP coverage reporting
- make the mock SAP server reject missing or wrong coverage request bodies

## Verification

- coverage contract and JaCoCo formatter suites: 29 passed
- CLI/MCP coverage parity suite: 3 passed
- `adt-contracts` typecheck: passed
- `adt-contracts`, `adt-aunit`, and `adt-mcp` builds: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send SAP-required coverage request bodies and switch statements to POST to match the ADT protocol. Previously we sent an empty measurements body and used a bodyless GET for statements (returned 400); now we POST a cov:query for measurements and a cov:statementsBulkRequest for statements, and only POST statements when links exist.

- Impact and migration:
  - `@abapify/adt-contracts`: measurements now requires post(id, body: string) with Content-Type application/xml; statements changes from get(id) to post(id, body: string). Exports `buildCoverageQuery`, `extractCoverageStatementUris` (de-duplicates), `buildStatementsBulkRequest`, and `coverageXmlBody`. Keep Accept: application/xml+scov.
  - Update callers to pass a cov:query to measurements and switch to statements.post with a cov:statementsBulkRequest; only POST statements when extracted links exist.
  - `adt-aunit` and `adt-mcp`: encapsulate the coverage flow in a shared fetch that builds the cov:query from target URIs, extracts per-object statement links from the measurement tree, and POSTs statements only when links exist.
  - `@abapify/adt-fixtures`: mock server enforces correct bodies and rejects missing, wrong, or root-only payloads; parity test asserts 400 on root-only bodies.

<sup>Written for commit f2ccf5a724123b647d4d814cd01897033f9ad2d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved code coverage retrieval by targeting specific objects and requesting related statements in bulk.
  * Added support for XML-based coverage queries and statement requests.
* **Bug Fixes**
  * Enhanced coverage handling when no statement data is available.
  * Added validation for coverage request payloads to provide clearer rejection of invalid requests.
* **Documentation**
  * Updated coverage endpoint documentation to reflect the new request methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->