### PR TITLE
fix(coverage): request SAP XML responses

### DIFF
--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/measurements.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/measurements.ts
@@ -5,15 +5,15 @@
  * created measurement. Used as the second step of the aunit → coverage
  * flow: aunit run → atom:link to measurement → POST this endpoint.
  *
- * Content-Type: application/xml+scov
- * Accept:       application/xml+scov
+ * Content-Type: application/xml
+ * Accept:       application/xml
  */
 
 import { http, contract } from '../../../../base';
 import { acoverageResult } from '../../../../schemas';
 import { coverageXmlBody } from './request';
 
-const SCOV_CONTENT_TYPE = 'application/xml+scov';
+const XML_CONTENT_TYPE = 'application/xml';
 
 export const measurements = contract({
   /**
@@ -31,7 +31,7 @@ export const measurements = contract({
         body: coverageXmlBody,
         responses: { 200: acoverageResult },
         headers: {
-          Accept: SCOV_CONTENT_TYPE,
+          Accept: XML_CONTENT_TYPE,
           'Content-Type': 'application/xml',
         },
       },

--- a/packages/adt-contracts/src/adt/runtime/traces/coverage/statements.ts
+++ b/packages/adt-contracts/src/adt/runtime/traces/coverage/statements.ts
@@ -4,14 +4,15 @@
  * POST returns the cov:statementsBulkResponse with per-method statement
  * / branch / procedure coverage details.
  *
- * Content-Type: application/xml+scov
+ * Content-Type: application/xml
+ * Accept:       application/xml
  */
 
 import { http, contract } from '../../../../base';
 import { acoverageStatements } from '../../../../schemas';
 import { coverageXmlBody } from './request';
 
-const SCOV_CONTENT_TYPE = 'application/xml+scov';
+const XML_CONTENT_TYPE = 'application/xml';
 
 export const statements = contract({
   /**
@@ -24,7 +25,7 @@ export const statements = contract({
         body: coverageXmlBody,
         responses: { 200: acoverageStatements },
         headers: {
-          Accept: SCOV_CONTENT_TYPE,
+          Accept: XML_CONTENT_TYPE,
           'Content-Type': 'application/xml',
         },
       },

--- a/packages/adt-contracts/tests/contracts/coverage.test.ts
+++ b/packages/adt-contracts/tests/contracts/coverage.test.ts
@@ -25,7 +25,7 @@ import {
 import { ContractScenario, runScenario, type ContractOperation } from './base';
 import { TypedContractScenario, runTypedScenario } from './base/typed-scenario';
 
-const SCOV_CONTENT_TYPE = 'application/xml+scov';
+const XML_CONTENT_TYPE = 'application/xml';
 
 // ─────────────────────────────────────────────────────────────
 // 1. Structural contract scenario
@@ -40,7 +40,7 @@ class CoverageContractScenario extends ContractScenario {
       method: 'POST',
       path: '/sap/bc/adt/runtime/traces/coverage/measurements/ABCDEF123',
       headers: {
-        Accept: SCOV_CONTENT_TYPE,
+        Accept: XML_CONTENT_TYPE,
         'Content-Type': 'application/xml',
       },
       query: { withAdditionalTypeInfo: true },
@@ -57,7 +57,7 @@ class CoverageContractScenario extends ContractScenario {
       method: 'POST',
       path: '/sap/bc/adt/runtime/traces/coverage/results/ABCDEF123/statements',
       headers: {
-        Accept: SCOV_CONTENT_TYPE,
+        Accept: XML_CONTENT_TYPE,
         'Content-Type': 'application/xml',
       },
       body: { schema: coverageXmlBody },


### PR DESCRIPTION
## **User description**
## Summary

- negotiate `application/xml` responses for coverage measurement and statement POSTs
- retain `application/xml` request bodies
- align the typed contract with the proven sapcli protocol

## Why

A live SAP ADT endpoint accepted the corrected XML POST body but rejected `Accept: application/xml+scov` with HTTP 406. The reference sapcli implementation sends `application/xml` request content and does not request the `+scov` response media type.

Primary source: https://github.com/jfilak/sapcli/blob/cb05a8ec2eef2e62a091d23cb1582e79417f5151/sap/adt/acoverage.py

## Verification

- 38 focused coverage contract, formatter, and CLI/MCP parity tests pass
- `adt-contracts`, `adt-aunit`, `adt-cli`, and `adt-mcp` builds pass
- branch contains one commit on current `main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Request SAP coverage responses as plain XML to match ADT behavior and avoid HTTP 406. Previously we sent `Accept: application/xml+scov`; now we send `Accept: application/xml` while keeping request bodies as `application/xml`.

- Updates `measurements` and `statements` contracts in `adt-contracts` to use `Accept: application/xml`; comments and tests adjusted.
- No schema or payload changes; aligns with sapcli protocol.
- Migration: if a client overrides headers to request `+scov`, change to `Accept: application/xml`.

<sup>Written for commit b50cead8be041265110387f46c567e99c5eca8c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Request standard XML responses for SAP coverage data

### What Changed
- Coverage measurement and statement requests now ask SAP for `application/xml` responses instead of the unsupported `application/xml+scov` media type
- Coverage requests continue sending XML bodies with the standard `application/xml` content type
- Contract tests now verify the corrected request and response headers

### Impact
`✅ Fewer SAP coverage requests rejected with HTTP 406`
`✅ Successful coverage measurement retrieval`
`✅ Successful coverage statement retrieval`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
