### PR TITLE
fix(aunit): emit GitLab-resolvable JaCoCo paths

### DIFF
--- a/packages/adt-aunit/src/commands/aunit.ts
+++ b/packages/adt-aunit/src/commands/aunit.ts
@@ -32,7 +32,11 @@ const ansi = {
   dim: (s: string) => `\x1b[2m${s}\x1b[0m`,
 };
 import { outputJunitReport, outputSonarReport } from '../formatters';
-import { toJacocoXml, toSonarGenericCoverageXml } from '../formatters/jacoco';
+import {
+  createAbapGitCoverageSourceResolver,
+  toJacocoXml,
+  toSonarGenericCoverageXml,
+} from '../formatters/jacoco';
 import type {
   AunitResult,
   AunitProgram,
@@ -675,10 +679,19 @@ export const aunitCommand: CliCommandPlugin = {
             targetUris,
           );
           const format = options.coverageFormat ?? 'jacoco';
+          const sourcePathResolver = createAbapGitCoverageSourceResolver();
           const xml =
             format === 'sonar-generic'
-              ? toSonarGenericCoverageXml({ measurements, statements })
-              : toJacocoXml({ measurements, statements });
+              ? toSonarGenericCoverageXml({
+                  measurements,
+                  statements,
+                  sourcePathResolver,
+                })
+              : toJacocoXml({
+                  measurements,
+                  statements,
+                  sourcePathResolver,
+                });
           if (options.coverageOutput) {
             const { writeFileSync } = await import('node:fs');
             writeFileSync(options.coverageOutput, xml, 'utf-8');

--- a/packages/adt-aunit/src/formatters/index.ts
+++ b/packages/adt-aunit/src/formatters/index.ts
@@ -5,5 +5,7 @@ export {
   outputJacocoReport,
   toSonarGenericCoverageXml,
   outputSonarGenericCoverageReport,
+  createAbapGitCoverageSourceResolver,
   type JacocoInput,
+  type CoverageSourcePathResolver,
 } from './jacoco';

--- a/packages/adt-aunit/src/formatters/jacoco.ts
+++ b/packages/adt-aunit/src/formatters/jacoco.ts
@@ -30,13 +30,14 @@
  *     <counter …/>
  *   </report>
  *
- * Improvement over sapcli: we use adtUriToAbapGitPath() so the
- * <sourcefile name=…> matches the on-disk abapGit filename (e.g.
- * `cl_foo.clas.abap`), making the report directly consumable by
- * SonarQube.
+ * Improvement over sapcli: we use adtUriToAbapGitPath() and an optional
+ * repository resolver so JaCoCo package + sourcefile names reconstruct the
+ * tracked abapGit path. GitLab can then match changed files for MR diff
+ * annotations, while standard JaCoCo consumers retain the same path.
  */
 
-import { writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, writeFileSync, type Dirent } from 'node:fs';
+import { basename, dirname, join, relative, sep } from 'node:path';
 import {
   acoverageResult,
   acoverageStatements,
@@ -101,6 +102,63 @@ function escapeAttr(s: string): string {
 
 function indent(level: number): string {
   return '   '.repeat(level);
+}
+
+function toPosix(filePath: string): string {
+  return sep === '/' ? filePath : filePath.split(sep).join('/');
+}
+
+function collectAbapSources(root: string): string[] {
+  const sources: string[] = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const candidate = join(directory, entry.name);
+      if (entry.isDirectory()) pending.push(candidate);
+      else if (entry.isFile() && entry.name.endsWith('.abap')) {
+        sources.push(candidate);
+      }
+    }
+  }
+  return sources;
+}
+
+export type CoverageSourcePathResolver = (
+  reportedPath: string,
+) => string | null;
+
+/** Resolve an abapGit basename to a unique repository-relative source path. */
+export function createAbapGitCoverageSourceResolver(
+  sourceRoot = 'src',
+  repositoryRoot = process.cwd(),
+): CoverageSourcePathResolver {
+  const absoluteSourceRoot = join(repositoryRoot, sourceRoot);
+  const byBasename = new Map<string, string[]>();
+  if (existsSync(absoluteSourceRoot)) {
+    for (const source of collectAbapSources(absoluteSourceRoot)) {
+      const name = basename(source);
+      const matches = byBasename.get(name) ?? [];
+      matches.push(toPosix(relative(repositoryRoot, source)));
+      byBasename.set(name, matches);
+    }
+  }
+
+  return (reportedPath: string): string | null => {
+    const matches = byBasename.get(basename(reportedPath)) ?? [];
+    if (matches.length > 1) {
+      throw new Error(
+        `Ambiguous ABAP coverage source ${basename(reportedPath)}: ${matches.join(', ')}`,
+      );
+    }
+    return matches[0] ?? null;
+  };
 }
 
 /**
@@ -181,13 +239,14 @@ function emitCounters(
 
 // ─── Emit <class>, <sourcefile> ───────────────────────────────────────
 
-function sourcefileNameFor(ref: ObjectRef | undefined): string {
+function sourcefilePathFor(
+  ref: ObjectRef | undefined,
+  resolver: CoverageSourcePathResolver | undefined,
+): string {
   const uri = ref?.uri;
   const abapgit = uri ? adtUriToAbapGitPath(uri) : null;
   if (abapgit) {
-    // Strip the leading `src/` since JaCoCo `name` is the bare filename;
-    // full path can still be reconstructed by consumers.
-    return abapgit.replace(/^src\//, '');
+    return resolver?.(abapgit) ?? abapgit;
   }
   // Fallback: raw name
   return (ref?.name ?? 'UNKNOWN').toLowerCase();
@@ -195,13 +254,14 @@ function sourcefileNameFor(ref: ObjectRef | undefined): string {
 
 function emitClass(
   classNode: CoverageNode,
+  sourcePath: string,
   lineMap: Map<MethodKey, LineHit[]>,
   indentLevel: number,
   out: string[],
 ): void {
   const ref = classNode.objectReference;
   const className = ref?.name ?? 'UNKNOWN';
-  const sourcefile = sourcefileNameFor(ref);
+  const sourcefile = basename(sourcePath);
 
   out.push(
     `${indent(indentLevel)}<class name="${escapeAttr(className)}" sourcefilename="${escapeAttr(sourcefile)}">`,
@@ -250,17 +310,45 @@ function emitClass(
 function emitPackage(
   packageNode: CoverageNode,
   lineMap: Map<MethodKey, LineHit[]>,
+  resolver: CoverageSourcePathResolver | undefined,
   indentLevel: number,
   out: string[],
 ): void {
-  const packageName = packageNode.objectReference?.name ?? 'UNKNOWN';
-  out.push(`${indent(indentLevel)}<package name="${escapeAttr(packageName)}">`);
   const classNodes = packageNode.nodes?.node ?? [];
-  for (const classNode of classNodes) {
-    emitClass(classNode, lineMap, indentLevel + 1, out);
+  const byDirectory = new Map<
+    string,
+    Array<{ node: CoverageNode; sourcePath: string }>
+  >();
+  for (const node of classNodes) {
+    const sourcePath = sourcefilePathFor(node.objectReference, resolver);
+    const directory = dirname(sourcePath);
+    const group = byDirectory.get(directory) ?? [];
+    group.push({ node, sourcePath });
+    byDirectory.set(directory, group);
   }
-  emitCounters(packageNode, indentLevel + 1, out);
-  out.push(`${indent(indentLevel)}</package>`);
+
+  for (const [directory, classes] of byDirectory) {
+    out.push(`${indent(indentLevel)}<package name="${escapeAttr(directory)}">`);
+    for (const { node, sourcePath } of classes) {
+      emitClass(node, sourcePath, lineMap, indentLevel + 1, out);
+    }
+    for (const counterType of Object.keys(COUNTER_TYPE_MAPPING)) {
+      let total = 0;
+      let executed = 0;
+      for (const { node } of classes) {
+        const counter = node.coverages?.coverage?.find(
+          (coverage) => coverage.type === counterType,
+        );
+        total += counter?.total ?? 0;
+        executed += counter?.executed ?? 0;
+      }
+      if (total === 0 && executed === 0) continue;
+      out.push(
+        `${indent(indentLevel + 1)}<counter type="${COUNTER_TYPE_MAPPING[counterType]}" missed="${Math.max(0, total - executed)}" covered="${executed}"/>`,
+      );
+    }
+    out.push(`${indent(indentLevel)}</package>`);
+  }
 }
 
 // ─── Public API ───────────────────────────────────────────────────────
@@ -269,6 +357,7 @@ export interface JacocoInput {
   measurements: AcoverageResultSchema;
   statements?: AcoverageStatementsSchema;
   reportName?: string;
+  sourcePathResolver?: CoverageSourcePathResolver;
 }
 
 export function toJacocoXml(input: JacocoInput): string {
@@ -285,7 +374,7 @@ export function toJacocoXml(input: JacocoInput): string {
   if (root) {
     const packages = (root.nodes?.node as unknown as CoverageNode[]) ?? [];
     for (const pkg of packages) {
-      emitPackage(pkg, lineMap, 1, out);
+      emitPackage(pkg, lineMap, input.sourcePathResolver, 1, out);
     }
     emitCounters(root as unknown as CoverageNode, 1, out);
   }
@@ -318,7 +407,10 @@ export function toSonarGenericCoverageXml(input: JacocoInput): string {
   function walk(node: CoverageNode): void {
     const ref = node.objectReference;
     if (ref?.uri && ref.type?.startsWith('CLAS')) {
-      const filePath = adtUriToAbapGitPath(ref.uri);
+      const reportedPath = adtUriToAbapGitPath(ref.uri);
+      const filePath = reportedPath
+        ? (input.sourcePathResolver?.(reportedPath) ?? reportedPath)
+        : null;
       if (filePath) {
         const className = ref.name ?? '';
         const methods = node.nodes?.node ?? [];

--- a/packages/adt-aunit/src/formatters/jacoco.ts
+++ b/packages/adt-aunit/src/formatters/jacoco.ts
@@ -332,6 +332,9 @@ function emitPackage(
     for (const { node, sourcePath } of classes) {
       emitClass(node, sourcePath, lineMap, indentLevel + 1, out);
     }
+    // Repository-path resolution can split one SAP package across multiple
+    // JaCoCo packages. Roll up the class nodes actually emitted in this
+    // directory so each package counter remains consistent with its children.
     for (const counterType of Object.keys(COUNTER_TYPE_MAPPING)) {
       let total = 0;
       let executed = 0;

--- a/packages/adt-aunit/tests/formatters/jacoco.test.ts
+++ b/packages/adt-aunit/tests/formatters/jacoco.test.ts
@@ -1,10 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it, expect } from 'vitest';
 import { fixtures } from '@abapify/adt-fixtures';
 import { acoverageResult, acoverageStatements } from '@abapify/adt-schemas';
 import {
+  createAbapGitCoverageSourceResolver,
   toJacocoXml,
   toSonarGenericCoverageXml,
 } from '../../src/formatters/jacoco';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 // Load parsed fixtures once.
 async function loadCoverage() {
@@ -30,10 +42,11 @@ describe('toJacocoXml', () => {
     expect(xml).toContain('</report>');
   });
 
-  it('emits <package> nodes with the DEVC name', async () => {
+  it('uses repository directories as JaCoCo packages', async () => {
     const { measurements, statements } = await loadCoverage();
     const xml = toJacocoXml({ measurements, statements });
-    expect(xml).toContain('<package name="TEST_EXAMPLE_PACKAGE">');
+    expect(xml).toContain('<package name="src">');
+    expect(xml).not.toContain('<package name="TEST_EXAMPLE_PACKAGE">');
   });
 
   it('emits JaCoCo counter rollups for branch/procedure/statement', async () => {
@@ -129,13 +142,50 @@ describe('toJacocoXml', () => {
     const xml = toJacocoXml({
       measurements: injected as never,
       statements,
+      sourcePathResolver: () => 'src/zca_tools/foo.clas.abap',
     });
 
     // Now lines come through because class=FOO matches.
     expect(xml).toMatch(
       /<line nr="\d+" mi="(0|1)" ci="(0|1)" mb="0" cb="0"\/>/,
     );
+    expect(xml).toContain('<package name="src/zca_tools">');
     expect(xml).toContain('<sourcefile name="foo.clas.abap">');
+    expect(xml).not.toContain('TEST_PKG/src/zca_tools');
+  });
+
+  it('resolves a unique abapGit basename under the repository source root', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'adt-aunit-jacoco-'));
+    temporaryDirectories.push(workspace);
+    const packageDirectory = join(workspace, 'src', 'zca_tools');
+    mkdirSync(packageDirectory, { recursive: true });
+    writeFileSync(
+      join(packageDirectory, 'foo.clas.abap'),
+      'CLASS foo DEFINITION. ENDCLASS.\n',
+    );
+
+    const resolver = createAbapGitCoverageSourceResolver('src', workspace);
+
+    expect(resolver('src/foo.clas.abap')).toBe('src/zca_tools/foo.clas.abap');
+  });
+
+  it('fails closed when an abapGit basename is ambiguous', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'adt-aunit-jacoco-'));
+    temporaryDirectories.push(workspace);
+    for (const packageName of ['package_a', 'package_b']) {
+      const packageDirectory = join(workspace, 'src', packageName);
+      mkdirSync(packageDirectory, { recursive: true });
+      writeFileSync(
+        join(packageDirectory, 'foo.clas.abap'),
+        'CLASS foo DEFINITION. ENDCLASS.\n',
+      );
+    }
+
+    const resolver = createAbapGitCoverageSourceResolver('src', workspace);
+
+    expect(() => resolver('src/foo.clas.abap')).toThrow(
+      /ambiguous ABAP coverage source foo\.clas\.abap/i,
+    );
   });
 
   it('honours an override reportName', async () => {

--- a/packages/adt-aunit/tests/formatters/jacoco.test.ts
+++ b/packages/adt-aunit/tests/formatters/jacoco.test.ts
@@ -58,6 +58,43 @@ describe('toJacocoXml', () => {
     expect(xml).toContain('<counter type="INSTRUCTION"');
   });
 
+  it('rolls up package counters from the classes emitted in each directory', () => {
+    const measurements = {
+      result: {
+        nodes: {
+          node: [
+            {
+              objectReference: { name: 'SAP_PACKAGE', type: 'DEVC/K' },
+              coverages: {
+                coverage: [{ type: 'statement', total: 999, executed: 999 }],
+              },
+              nodes: {
+                node: [
+                  {
+                    objectReference: { name: 'FOO', type: 'CLAS/OC' },
+                    coverages: {
+                      coverage: [{ type: 'statement', total: 10, executed: 8 }],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const xml = toJacocoXml({
+      measurements: measurements as never,
+      sourcePathResolver: () => 'src/zca_tools/foo.clas.abap',
+    });
+
+    expect(xml).toContain(
+      '<counter type="INSTRUCTION" missed="2" covered="8"/>',
+    );
+    expect(xml).not.toContain('covered="999"');
+  });
+
   it('emits <sourcefile> with abapGit path convention', async () => {
     const { measurements, statements } = await loadCoverage();
     const xml = toJacocoXml({ measurements, statements });

--- a/packages/adt-cli/tests/e2e/parity.coverage.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.coverage.test.ts
@@ -106,8 +106,9 @@ describe('CLI + MCP parity (aunit coverage)', () => {
       '<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">',
     );
     expect(stdout).toContain('<report name="ABAP Coverage">');
-    // The mock measurements tree uses CL_EXAMPLE_CLASS / TEST_EXAMPLE_PACKAGE.
-    expect(stdout).toContain('<package name="TEST_EXAMPLE_PACKAGE">');
+    // No matching repository source exists for the fixture, so the resolver
+    // falls back to the conventional abapGit source root.
+    expect(stdout).toContain('<package name="src">');
     expect(stdout).toMatch(/sourcefilename="cl_example_class\.clas\.abap"/);
   });
 


### PR DESCRIPTION
## Problem

GitLab resolves JaCoCo coverage by combining `<package name>` and `<sourcefile name>`. The current ABAP Unit formatter emits the ABAP program name as the package and a repository path as the source file, producing a path that cannot match changed files in merge requests.

## Fix

- index repository `.abap` sources by basename
- resolve each coverage source to a unique repository-relative path
- emit the directory as the JaCoCo package and the basename as class/sourcefile
- group and aggregate package counters when resolved files live in different directories
- fail closed when the same basename is ambiguous
- apply the resolver automatically to JaCoCo and Sonar coverage generation

No new CLI input is required. JaCoCo package counters are deliberately rolled up from the class nodes emitted in each resolved directory, keeping parent metrics consistent when one SAP package is split across repository directories.

## Verification

- focused JaCoCo formatter tests: 11 passed
- focused CLI/MCP coverage parity tests: 4 passed
- `NX_CLOUD=false bunx nx test adt-aunit`: passed
- `NX_CLOUD=false bunx nx lint adt-aunit`: passed
- `NX_CLOUD=false bunx nx build adt-aunit`: passed
- upstream aggregate `main` check: passed

The package-wide typecheck still reports pre-existing errors in the unrelated `adt-plugin-abapgit` project; the changed files introduce no reported type error.

Internal Draft shadow review (must not be merged): https://gitlab.com/booking-com/finsys-devops/adt-cli/-/merge_requests/60