### PR TITLE
feat(flow): persist complete CTS inventories

### DIFF
--- a/openspec/changes/add-adt-flow-transport-checkout/design.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/design.md
@@ -129,12 +129,16 @@ An object descriptor records only relevant data:
 
 A transport descriptor is written only by successful head checkout, so
 `.adt/tr/<TR>.json` first appears with the externally created transport commit,
-not in a base commit. It records normalized requested/scope transports,
-relevant object identities, head selection, config/format digests, and released
-transport metadata. Base checkout updates only predecessor object descriptors
+not in a base commit. One descriptor is written for every request/task discovered
+in the scope. It records normalized requested/scope transports, the complete CTS
+object inventory with concrete task provenance, relevant materialized object
+descriptors, and config/format digests. Unsupported and currently filtered object
+identities remain in the inventory so a later format/configuration upgrade can
+identify the exact transports that need another materialization attempt. Base
+checkout updates only predecessor object descriptors
 that actually exist; it does not pre-create the reviewed transport descriptor
 or an absent descriptor for a newly created object. Descriptors exclude source bodies,
-credentials, unrelated transport objects, absolute paths, and wall-clock
+credentials, source bodies, absolute paths, and wall-clock
 `fetchedAt` values.
 
 Deleting `.adt` forces discovery and selected-source reads again but does not

--- a/openspec/changes/add-adt-flow-transport-checkout/proposal.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/proposal.md
@@ -21,7 +21,9 @@ the source immediately before it and the source introduced by it.
 - Add deterministic `.adt/tr/<TR>.json` and
   `.adt/objects/<TYPE>/<encoded-name>.<type>.adt.json` descriptors as an optional,
   committed incremental index. Head checkout writes the reviewed transport
-  descriptor; base checkout writes predecessor object descriptors. Removing
+  descriptor for every discovered request/task and retains the complete CTS
+  object inventory, including objects not yet supported by the active format.
+  Base checkout writes predecessor object descriptors. Removing
   `.adt` affects performance, not source selection correctness.
 - Add a pure format-materialization extension to `@abapify/adt-plugin` and an
   abapGit implementation. The MVP supports only abapGit output while keeping
@@ -31,7 +33,8 @@ the source immediately before it and the source introduced by it.
 - Fail closed before filesystem mutation when the source boundary is
   ambiguous or failed, or when paths collide or diverge from indexed state;
   record and skip unsupported object types so exact source components in the
-  same transport remain reviewable.
+  same transport remain reviewable and the skipped inventory can be retried
+  when support is added.
 - Explicitly limit MVP exactness to versioned source components. Full history
   replication and reconstruction of historical object metadata are deferred.
 

--- a/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
@@ -118,7 +118,9 @@ Checkout SHALL maintain deterministic transport and object descriptors under
 #### Scenario: Successful head checkout
 
 - **WHEN** a relevant transport head is checked out successfully
-- **THEN** `.adt/tr/<TR>.json` records the normalized boundary selection without source bodies or unrelated objects
+- **THEN** `.adt/tr/<TR>.json` records the normalized boundary selection without source bodies
+- **THEN** every request/task discovered in the scope has its own descriptor
+- **THEN** each descriptor retains its complete CTS object inventory, including unsupported and currently filtered types
 - **THEN** each relevant object has a uniquely named descriptor under `.adt/objects/<TYPE>/`
 - **THEN** descriptors contain no credentials, absolute paths, or wall-clock-only values
 
@@ -176,6 +178,13 @@ from the root `adt.config.ts` and SHALL persist only relevant identities.
 - **WHEN** checkout is executed again
 - **THEN** the changed config digest invalidates the affected fast path
 - **THEN** newly relevant objects are discovered without requiring a complete system clone
+
+#### Scenario: A previously unsupported type becomes materializable
+
+- **GIVEN** a committed transport descriptor inventories an unsupported CTS object
+- **WHEN** the active flow implementation and configuration later support that repository type
+- **THEN** the descriptor identifies the concrete request/task that must be retried
+- **THEN** a successful head checkout replaces the pending inventory-only state with materialized object descriptors without losing the original CTS identity
 
 ### Requirement: MVP exactness is limited to source
 

--- a/openspec/changes/add-adt-flow-transport-checkout/tasks.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/tasks.md
@@ -59,3 +59,10 @@
 - [x] 8.1 Add a failing indexed-flow test proving an `added` parent-boundary manifest preserves the prior task state in base mode.
 - [x] 8.2 Reuse the verified present descriptor and owned files as the incremental base without source or mutable-state reads.
 - [x] 8.3 Prove an unindexed format-recognizable tree remains unchanged in base mode and is adopted by head checkout.
+
+## 9. Preserve complete CTS inventory for later materialization
+
+- [x] 9.1 Add failing tests proving selector-excluded and unsupported CTS objects remain in the manifest inventory.
+- [x] 9.2 Persist one `.adt/tr/<TR>.json` descriptor per discovered request/task with concrete object provenance.
+- [x] 9.3 Resolve supported LIMU leaves through their `wbtype` and ADT owner URI while preserving the original CTS identity.
+- [ ] 9.4 Prove an inventory-only task survives the consumer's state-only publication path and can be retried after support expands.

--- a/openspec/changes/add-adt-flow-transport-checkout/tasks.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/tasks.md
@@ -65,4 +65,4 @@
 - [x] 9.1 Add failing tests proving selector-excluded and unsupported CTS objects remain in the manifest inventory.
 - [x] 9.2 Persist one `.adt/tr/<TR>.json` descriptor per discovered request/task with concrete object provenance.
 - [x] 9.3 Resolve supported LIMU leaves through their `wbtype` and ADT owner URI while preserving the original CTS identity.
-- [ ] 9.4 Prove an inventory-only task survives the consumer's state-only publication path and can be retried after support expands.
+- [x] 9.4 Prove an inventory-only task survives the consumer's state-only publication path and can be retried after support expands (covered by the downstream consumer regression).

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -1,7 +1,7 @@
 import { assertAdtUri, type SourceVersionRef } from '@abapify/adt-client';
 import type { AdkContext } from './base/context';
 import { getGlobalContext } from './base/global-context';
-import { normalizeObjectName } from './base/registry';
+import { getEndpointForType, normalizeObjectName } from './base/registry';
 import { createAdkFactory } from './factory';
 import {
   resolveTransportObjects,
@@ -102,13 +102,25 @@ export interface TransportSourceManifestComponent {
 
 export interface TransportSourceManifestEntry extends TransportSourceVersionSelection {
   object: TransportSourceManifestObject;
+  repositoryObject?: TransportSourceManifestObject;
   component: TransportSourceManifestComponent;
+  sourceTransport: string;
+}
+
+export interface TransportObjectInventoryEntry {
+  pgmid: string;
+  type: string;
+  name: string;
+  wbtype?: string;
+  uri?: string;
+  objFunc: string;
   sourceTransport: string;
 }
 
 export interface TransportSourceManifest {
   requestedTransports: string[];
   scopeTransports: string[];
+  inventory: TransportObjectInventoryEntry[];
   entries: TransportSourceManifestEntry[];
 }
 
@@ -628,6 +640,127 @@ export function selectTransportSourceVersions( // NOSONAR - SAP feed-order selec
 
 type TransportObjectReference = ResolvedTransportObjects['objects'][number];
 
+interface RepositoryObjectReference {
+  pgmid: string;
+  type: string;
+  name: string;
+  isDeleted: boolean;
+}
+
+function repositoryNameFromUri(
+  uri: string | undefined,
+  type: string,
+): string | undefined {
+  if (!uri) return undefined;
+  const endpoint = getEndpointForType(type);
+  if (!endpoint) return undefined;
+  const prefix = `/sap/bc/adt/${endpoint}/`;
+  if (!uri.startsWith(prefix)) return undefined;
+  const encodedName = uri.slice(prefix.length).split('/')[0];
+  if (!encodedName) return undefined;
+  try {
+    const name = decodeURIComponent(encodedName).trim().toUpperCase();
+    return name || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve a LIMU leaf to the repository object that owns its source. */
+function repositoryObjectReference(
+  reference: TransportObjectReference,
+): RepositoryObjectReference {
+  const pgmid = reference.pgmid.trim().toUpperCase();
+  const rawType = reference.type.trim().toUpperCase().split('/')[0] ?? '';
+  if (pgmid === 'LIMU') {
+    const ownerType = reference.wbtype?.trim().toUpperCase();
+    const ownerName = ownerType
+      ? repositoryNameFromUri(reference.uri, ownerType)
+      : undefined;
+    if (ownerType && ownerName) {
+      return {
+        pgmid: 'R3TR',
+        type: ownerType,
+        name: ownerName,
+        // A deleted leaf changes its owner. Only REPS preserves the legacy
+        // whole-program deletion behavior when no R3TR parent is present.
+        isDeleted: rawType === 'REPS' && reference.isDeleted,
+      };
+    }
+    if (rawType === 'REPS') {
+      return {
+        pgmid: 'R3TR',
+        type: 'PROG',
+        name: reference.name.trim().toUpperCase(),
+        isDeleted: reference.isDeleted,
+      };
+    }
+  }
+  return {
+    pgmid,
+    type: reference.type,
+    name: reference.name,
+    isDeleted: reference.isDeleted,
+  };
+}
+
+function selectorValues(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  return (Array.isArray(value) ? value : [value]).map((item) =>
+    item.trim().toUpperCase(),
+  );
+}
+
+function selectorDimensionMatches(
+  candidates: readonly string[],
+  expected: string | string[] | undefined,
+): boolean {
+  const values = selectorValues(expected);
+  if (values.length === 0) return true;
+  return values.some(
+    (value) => value === '*' || candidates.some((item) => item === value),
+  );
+}
+
+function manifestSelectorMatches(
+  original: TransportObjectReference,
+  repository: RepositoryObjectReference,
+  selector: TransportObjectSelector | undefined,
+): boolean {
+  if (!selector) return true;
+  return (
+    selectorDimensionMatches(
+      [original.objFunc.trim().toUpperCase()],
+      selector.objFunc,
+    ) &&
+    selectorDimensionMatches(
+      [original.pgmid.trim().toUpperCase(), repository.pgmid],
+      selector.pgmid,
+    ) &&
+    selectorDimensionMatches(
+      [original.type.trim().toUpperCase(), repository.type.toUpperCase()],
+      selector.type,
+    )
+  );
+}
+
+function inventoryEntry(
+  reference: TransportObjectReference,
+  sourceTransport: string,
+): TransportObjectInventoryEntry {
+  const wbtype = reference.wbtype?.trim().toUpperCase();
+  const uri = reference.uri?.trim();
+  return {
+    pgmid: reference.pgmid.trim().toUpperCase(),
+    type: reference.type.trim().toUpperCase(),
+    name: reference.name.trim().toUpperCase(),
+    ...(wbtype ? { wbtype } : {}),
+    ...(uri ? { uri } : {}),
+    objFunc: reference.objFunc.trim().toUpperCase(),
+    sourceTransport,
+  };
+}
+
 /**
  * CTS exposes a program's main source as the LIMU/REPS sub-object, while ADT
  * exposes the same source history through the repository PROG resource. Keep
@@ -635,7 +768,7 @@ type TransportObjectReference = ResolvedTransportObjects['objects'][number];
  * metadata and immutable-version discovery.
  */
 function sourceHistoryDiscoveryType(
-  reference: TransportObjectReference,
+  reference: RepositoryObjectReference,
 ): string {
   const pgmid = reference.pgmid.trim().toUpperCase();
   const type = reference.type.trim().toUpperCase().split('/')[0];
@@ -643,21 +776,41 @@ function sourceHistoryDiscoveryType(
 }
 
 async function buildObjectEntries( // NOSONAR - SAP object manifest construction is branch-heavy; will be refactored in follow-up
-  reference: TransportObjectReference,
+  original: TransportObjectReference,
+  repository: RepositoryObjectReference,
   sourceTransport: string,
   scopeTransportNumbers: readonly string[],
   ctx: AdkContext,
 ): Promise<TransportSourceManifestEntry[]> {
   const baseIdentity: TransportSourceManifestObject = {
-    pgmid: reference.pgmid,
-    type: reference.type,
-    name: reference.name,
+    pgmid: original.pgmid,
+    type: original.type,
+    name: original.name,
   };
+  const hasRepositoryOwner =
+    repository.pgmid !== baseIdentity.pgmid ||
+    repository.type !== baseIdentity.type ||
+    repository.name !== baseIdentity.name;
+  const withRepositoryOwner = (
+    entry: TransportSourceManifestEntry,
+    packageName?: string,
+  ): TransportSourceManifestEntry =>
+    hasRepositoryOwner
+      ? {
+          ...entry,
+          repositoryObject: {
+            pgmid: repository.pgmid,
+            type: repository.type,
+            name: repository.name,
+            ...(packageName ? { packageName } : {}),
+          },
+        }
+      : entry;
   let discovery: ObjectSourceDiscovery;
   try {
     discovery = await discoverObjectSourceHistory(
-      reference.name,
-      sourceHistoryDiscoveryType(reference),
+      repository.name,
+      sourceHistoryDiscoveryType(repository),
       ctx,
       false,
     );
@@ -670,15 +823,17 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
         : {}),
     };
     return [
-      unavailableEntry(
-        failureIdentity,
-        { id: 'object' },
-        sourceTransport,
-        'unsupported',
-        {
-          code: error.code,
-          message: error.message,
-        },
+      withRepositoryOwner(
+        unavailableEntry(
+          failureIdentity,
+          { id: 'object' },
+          sourceTransport,
+          'unsupported',
+          {
+            code: error.code,
+            message: error.message,
+          },
+        ),
       ),
     ];
   }
@@ -700,12 +855,15 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
 
     if (component.diagnostic) {
       entries.push(
-        unavailableEntry(
-          identity,
-          publicComponent,
-          sourceTransport,
-          'unsupported',
-          component.diagnostic,
+        withRepositoryOwner(
+          unavailableEntry(
+            identity,
+            publicComponent,
+            sourceTransport,
+            'unsupported',
+            component.diagnostic,
+          ),
+          discovery.object.packageName,
         ),
       );
       continue;
@@ -713,15 +871,18 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
 
     if (!component.versionsUri) {
       entries.push(
-        unavailableEntry(
-          identity,
-          publicComponent,
-          sourceTransport,
-          'unsupported',
-          {
-            code: 'SOURCE_COMPONENT_VERSIONS_UNAVAILABLE',
-            message: 'The source component has no exact versions relation.',
-          },
+        withRepositoryOwner(
+          unavailableEntry(
+            identity,
+            publicComponent,
+            sourceTransport,
+            'unsupported',
+            {
+              code: 'SOURCE_COMPONENT_VERSIONS_UNAVAILABLE',
+              message: 'The source component has no exact versions relation.',
+            },
+          ),
+          discovery.object.packageName,
         ),
       );
       continue;
@@ -734,10 +895,19 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
       );
     } catch {
       entries.push(
-        unavailableEntry(identity, publicComponent, sourceTransport, 'failed', {
-          code: 'SOURCE_HISTORY_RETRIEVAL_FAILED',
-          message: 'SAP ADT rejected source-history metadata retrieval.',
-        }),
+        withRepositoryOwner(
+          unavailableEntry(
+            identity,
+            publicComponent,
+            sourceTransport,
+            'failed',
+            {
+              code: 'SOURCE_HISTORY_RETRIEVAL_FAILED',
+              message: 'SAP ADT rejected source-history metadata retrieval.',
+            },
+          ),
+          discovery.object.packageName,
+        ),
       );
       continue;
     }
@@ -745,14 +915,19 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
     const selection = selectTransportSourceVersions(
       versions,
       scopeTransportNumbers,
-      reference.isDeleted,
+      repository.isDeleted,
     );
-    entries.push({
-      object: identity,
-      component: publicComponent,
-      sourceTransport,
-      ...selection,
-    });
+    entries.push(
+      withRepositoryOwner(
+        {
+          object: identity,
+          component: publicComponent,
+          sourceTransport,
+          ...selection,
+        },
+        discovery.object.packageName,
+      ),
+    );
   }
 
   return entries;
@@ -840,31 +1015,58 @@ export async function buildTransportSourceManifest(
 ): Promise<TransportSourceManifest> {
   const context = ctx ?? getGlobalContext();
   const requested = uniqueStable(requestedTransports);
-  const resolved = await resolveTransportObjects(
-    requested,
-    options.selector ?? {},
-    context,
-  );
+  const resolved = await resolveTransportObjects(requested, {}, context);
   const scopeTransports = uniqueStable([
     ...requested,
     ...resolved.scopeTransportNumbers,
   ]);
-  const objects = resolved.objects
-    .filter((reference) => !isNonSourceCtsObject(reference))
+  const inventory = resolved.objects
+    .map((reference) =>
+      inventoryEntry(
+        reference,
+        resolved.sourceTransportMap.get(reference.key) ?? requested[0] ?? '',
+      ),
+    )
     .sort(
       (left, right) =>
+        compareText(left.sourceTransport, right.sourceTransport) ||
         compareText(left.pgmid, right.pgmid) ||
         compareText(left.type, right.type) ||
         compareText(left.name, right.name),
+    );
+  const seenRepositoryObjects = new Set<string>();
+  const objects = resolved.objects
+    .filter((reference) => !isNonSourceCtsObject(reference))
+    .map((original) => ({
+      original,
+      repository: repositoryObjectReference(original),
+      sourceTransport:
+        resolved.sourceTransportMap.get(original.key) ?? requested[0] ?? '',
+    }))
+    .filter(({ original, repository }) =>
+      manifestSelectorMatches(original, repository, options.selector),
+    )
+    .filter(({ repository }) => {
+      const key = `${repository.pgmid}/${repository.type}/${repository.name}`;
+      if (seenRepositoryObjects.has(key)) return false;
+      seenRepositoryObjects.add(key);
+      return true;
+    })
+    .sort(
+      (left, right) =>
+        compareText(left.repository.pgmid, right.repository.pgmid) ||
+        compareText(left.repository.type, right.repository.type) ||
+        compareText(left.repository.name, right.repository.name),
     );
 
   const perObjectEntries = await mapOrdered(
     objects,
     normalizeConcurrency(options.concurrency),
-    (reference) =>
+    ({ original, repository, sourceTransport }) =>
       buildObjectEntries(
-        reference,
-        resolved.sourceTransportMap.get(reference.key) ?? '',
+        original,
+        repository,
+        sourceTransport,
         scopeTransports,
         context,
       ),
@@ -873,6 +1075,7 @@ export async function buildTransportSourceManifest(
   return {
     requestedTransports: requested,
     scopeTransports,
+    inventory,
     entries: perObjectEntries.flat(),
   };
 }

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -671,7 +671,8 @@ function repositoryObjectReference(
   reference: TransportObjectReference,
 ): RepositoryObjectReference {
   const pgmid = reference.pgmid.trim().toUpperCase();
-  const rawType = reference.type.trim().toUpperCase().split('/')[0] ?? '';
+  const rawTypeFull = reference.type.trim().toUpperCase();
+  const rawType = rawTypeFull.split('/')[0] ?? '';
   if (pgmid === 'LIMU') {
     const ownerType = reference.wbtype?.trim().toUpperCase();
     const ownerName = ownerType
@@ -698,8 +699,8 @@ function repositoryObjectReference(
   }
   return {
     pgmid,
-    type: reference.type,
-    name: reference.name,
+    type: rawTypeFull,
+    name: reference.name.trim().toUpperCase(),
     isDeleted: reference.isDeleted,
   };
 }
@@ -717,9 +718,7 @@ function selectorDimensionMatches(
 ): boolean {
   const values = selectorValues(expected);
   if (values.length === 0) return true;
-  return values.some(
-    (value) => value === '*' || candidates.some((item) => item === value),
-  );
+  return values.some((value) => value === '*' || candidates.includes(value));
 }
 
 function manifestSelectorMatches(

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -46,8 +46,10 @@ interface FakeTransportObjectOptions {
   name: string;
   type?: string;
   pgmid?: string;
+  wbtype?: string;
   deleted?: boolean;
   objectUri?: string;
+  factoryName?: string;
   metadata?: Record<string, unknown>;
   load?: () => Promise<void>;
 }
@@ -59,13 +61,15 @@ function transportObject({
   name,
   type = 'PROG',
   pgmid = 'R3TR',
+  wbtype = type,
   deleted = false,
   objectUri = `/sap/bc/adt/programs/programs/${name.toLowerCase()}`,
+  factoryName = name,
   metadata = {},
   load,
 }: FakeTransportObjectOptions) {
   const key = `${pgmid}/${type}/${name}`;
-  factoryObjects.set(name, {
+  factoryObjects.set(factoryName, {
     objectUri,
     dataSync: metadata,
     load: load ?? vi.fn().mockResolvedValue(undefined),
@@ -75,6 +79,8 @@ function transportObject({
     pgmid,
     type,
     name,
+    wbtype,
+    uri: objectUri,
     objFunc: deleted ? 'D' : '',
     isDeleted: deleted,
   };
@@ -575,6 +581,17 @@ describe('buildTransportSourceManifest', () => {
     ).resolves.toEqual({
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001', 'DEVK900002'],
+      inventory: [
+        {
+          pgmid: 'R3TR',
+          type: 'PROG',
+          name: 'ZREPORT',
+          wbtype: 'PROG',
+          uri: '/sap/bc/adt/programs/programs/zreport',
+          objFunc: '',
+          sourceTransport: 'DEVK900002',
+        },
+      ],
       entries: [
         {
           object: {
@@ -663,6 +680,162 @@ describe('buildTransportSourceManifest', () => {
         head,
       }),
     ]);
+  });
+
+  it('retains every CTS object and resolves supported LIMU leaves through their repository owner', async () => {
+    const method = transportObject({
+      name: 'ZCL_REVIEWED                  APPLY_CHANGE',
+      type: 'METH',
+      pgmid: 'LIMU',
+      wbtype: 'CLAS',
+      objectUri: '/sap/bc/adt/oo/classes/zcl_reviewed/source/main',
+      factoryName: 'ZCL_REVIEWED',
+      metadata: rootSourceMetadata(),
+    });
+    const unsupported = transportObject({
+      name: 'ZUNSUPPORTED',
+      type: 'ZZZZ',
+      pgmid: 'LIMU',
+      wbtype: 'ZZZZ',
+      objectUri:
+        '/sap/bc/adt/repository/informationsystem/objectproperties/values',
+    });
+    mockResolution(
+      [method, unsupported],
+      ['DEVK900002', 'DEVK900002'],
+      ['DEVK900001', 'DEVK900002'],
+    );
+    const head = version('00002', 0, ['DEVK900002']);
+    const base = version('00001', 1, ['DEVK800001']);
+    const { ctx } = contextWithVersions(
+      vi.fn().mockResolvedValue([head, base]),
+    );
+
+    const manifest = await buildTransportSourceManifest(
+      ['DEVK900002'],
+      { selector: { type: ['CLAS'] } },
+      ctx,
+    );
+
+    expect(resolveTransportObjectsMock).toHaveBeenCalledWith(
+      ['DEVK900002'],
+      {},
+      ctx,
+    );
+    expect(manifest.inventory).toEqual([
+      {
+        pgmid: 'LIMU',
+        type: 'METH',
+        name: 'ZCL_REVIEWED                  APPLY_CHANGE',
+        wbtype: 'CLAS',
+        uri: '/sap/bc/adt/oo/classes/zcl_reviewed/source/main',
+        objFunc: '',
+        sourceTransport: 'DEVK900002',
+      },
+      {
+        pgmid: 'LIMU',
+        type: 'ZZZZ',
+        name: 'ZUNSUPPORTED',
+        wbtype: 'ZZZZ',
+        uri: '/sap/bc/adt/repository/informationsystem/objectproperties/values',
+        objFunc: '',
+        sourceTransport: 'DEVK900002',
+      },
+    ]);
+    expect(factoryGet).toHaveBeenCalledWith('ZCL_REVIEWED', 'CLAS');
+    expect(manifest.entries).toEqual([
+      expect.objectContaining({
+        object: {
+          pgmid: 'LIMU',
+          type: 'METH',
+          name: 'ZCL_REVIEWED                  APPLY_CHANGE',
+          packageName: 'ZPACKAGE',
+        },
+        repositoryObject: {
+          pgmid: 'R3TR',
+          type: 'CLAS',
+          name: 'ZCL_REVIEWED',
+          packageName: 'ZPACKAGE',
+        },
+        sourceTransport: 'DEVK900002',
+        changeKind: 'modified',
+        exact: true,
+      }),
+    ]);
+  });
+
+  it('canonicalizes function and namespaced class leaves without losing their CTS identities', async () => {
+    const functionModule = transportObject({
+      name: '/ESOURC/SVIM_IVALUA_SEND_DP',
+      type: 'FUNC',
+      pgmid: 'LIMU',
+      wbtype: 'FUGR',
+      objectUri:
+        '/sap/bc/adt/functions/groups/%2FESOURC%2FSVIM_IVALUA/source/main',
+      factoryName: '/ESOURC/SVIM_IVALUA',
+      metadata: rootSourceMetadata(),
+    });
+    const classDefinition = transportObject({
+      name: '/ESOURC/CL_SVIM_IVALUA',
+      type: 'CLSD',
+      pgmid: 'LIMU',
+      wbtype: 'CLAS',
+      objectUri:
+        '/sap/bc/adt/oo/classes/%2FESOURC%2FCL_SVIM_IVALUA/source/main',
+      factoryName: '/ESOURC/CL_SVIM_IVALUA',
+      metadata: rootSourceMetadata(),
+    });
+    const classPublicSection = transportObject({
+      name: '/ESOURC/CL_SVIM_IVALUA',
+      type: 'CPUB',
+      pgmid: 'LIMU',
+      wbtype: 'CLAS',
+      objectUri:
+        '/sap/bc/adt/oo/classes/%2FESOURC%2FCL_SVIM_IVALUA/source/main',
+      factoryName: '/ESOURC/CL_SVIM_IVALUA',
+      metadata: rootSourceMetadata(),
+    });
+    mockResolution(
+      [functionModule, classDefinition, classPublicSection],
+      ['DEVK900003', 'DEVK900003', 'DEVK900003'],
+      ['DEVK900003'],
+    );
+    const { ctx } = contextWithVersions(
+      vi
+        .fn()
+        .mockResolvedValue([
+          version('00002', 0, ['DEVK900003']),
+          version('00001', 1, ['DEVK800001']),
+        ]),
+    );
+
+    const manifest = await buildTransportSourceManifest(
+      ['DEVK900003'],
+      {},
+      ctx,
+    );
+
+    expect(manifest.inventory).toHaveLength(3);
+    expect(manifest.inventory.map(({ type }) => type).sort()).toEqual([
+      'CLSD',
+      'CPUB',
+      'FUNC',
+    ]);
+    expect(factoryGet).toHaveBeenCalledWith('/ESOURC/SVIM_IVALUA', 'FUGR');
+    expect(factoryGet).toHaveBeenCalledWith('/ESOURC/CL_SVIM_IVALUA', 'CLAS');
+    expect(manifest.entries).toHaveLength(2);
+    expect(manifest.entries.map((entry) => entry.repositoryObject)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'FUGR',
+          name: '/ESOURC/SVIM_IVALUA',
+        }),
+        expect.objectContaining({
+          type: 'CLAS',
+          name: '/ESOURC/CL_SVIM_IVALUA',
+        }),
+      ]),
+    );
   });
 
   it('ignores R3TR SUSK authorization-maintenance assignments as non-source entries', async () => {

--- a/packages/adt-cli/src/lib/commands/cts/tr/source-manifest.test.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/source-manifest.test.ts
@@ -44,6 +44,7 @@ describe('cts tr source-manifest', () => {
       async (input: { transports: string[] }) => ({
         requestedTransports: input.transports,
         scopeTransports: input.transports,
+        inventory: [],
         entries: [],
       }),
     );
@@ -73,6 +74,7 @@ describe('cts tr source-manifest', () => {
     const buildTransportManifest = vi.fn(async () => ({
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001', 'DEVK900011'],
+      inventory: [],
       entries: [
         {
           object: { pgmid: 'R3TR', type: 'CLAS', name: 'ZCL_TEST' },
@@ -105,6 +107,7 @@ describe('cts tr source-manifest', () => {
     const buildTransportManifest = vi.fn(async () => ({
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001'],
+      inventory: [],
       entries: [
         {
           object: { pgmid: 'R3TR', type: 'PROG', name: 'ZTEST' },

--- a/packages/adt-cli/src/lib/services/source-history/service.test.ts
+++ b/packages/adt-cli/src/lib/services/source-history/service.test.ts
@@ -3,6 +3,7 @@ import type { AdtClient } from '@abapify/adt-client';
 import {
   ExactSourceHistoryService,
   ExactSourceHistoryServiceError,
+  toMetadataOnlyTransportSourceManifest,
   type BuildTransportManifestResult,
   type ExactSourceHistoryOperations,
   type ListObjectVersionsResult,
@@ -36,6 +37,7 @@ function createOperations(results?: {
         results?.manifest ?? {
           requestedTransports: ['DEVK900001'],
           scopeTransports: ['DEVK900001'],
+          inventory: [],
           entries: [],
         },
       ),
@@ -112,5 +114,40 @@ describe('ExactSourceHistoryService', () => {
         'SAP ADT source-version metadata retrieval failed.',
       ),
     );
+  });
+
+  it('keeps the complete CTS inventory while stripping SAP object URIs', () => {
+    const output = toMetadataOnlyTransportSourceManifest({
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      inventory: [
+        {
+          pgmid: 'LIMU',
+          type: 'METH',
+          name: 'ZCL_TEST RUN',
+          wbtype: 'CLAS',
+          uri: '/sap/bc/adt/oo/classes/zcl_test',
+          objFunc: '',
+          sourceTransport: 'DEVK900001',
+        },
+      ],
+      entries: [],
+    });
+
+    expect(output).toEqual({
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      inventory: [
+        {
+          pgmid: 'LIMU',
+          type: 'METH',
+          name: 'ZCL_TEST RUN',
+          wbtype: 'CLAS',
+          objFunc: '',
+          sourceTransport: 'DEVK900001',
+        },
+      ],
+      entries: [],
+    });
   });
 });

--- a/packages/adt-cli/src/lib/services/source-history/service.ts
+++ b/packages/adt-cli/src/lib/services/source-history/service.ts
@@ -111,6 +111,7 @@ export function toMetadataOnlyTransportSourceManifest(
   return {
     requestedTransports: manifest.requestedTransports,
     scopeTransports: manifest.scopeTransports,
+    inventory: manifest.inventory.map(({ uri: _uri, ...entry }) => entry),
     entries: manifest.entries.map((entry) => {
       const { sourceUri: _s, versionsUri: _v, ...component } = entry.component;
       const stripSourceUri = (

--- a/packages/adt-flow/README.md
+++ b/packages/adt-flow/README.md
@@ -60,8 +60,10 @@ deterministic descriptors under `.adt`, rejects unowned collisions or modified
 indexed files before mutation, and rolls back a failed multi-file apply.
 Branches, commits, routing, and merge requests remain the caller's concern.
 
-`.adt/tr/<transport>.json` is emitted for head checkout, and object
-descriptors under `.adt/objects/` are written for both base and head. Object
+`.adt/tr/<transport>.json` is emitted for every request/task discovered during
+head checkout. Each transport descriptor retains the complete CTS object
+inventory, including unsupported or currently filtered types. Object descriptors
+under `.adt/objects/` are written for both base and head. Object
 descriptors use `.adt/objects/<TYPE>/<unique-name>.<type>.adt.json`. The index
 stores hashes and immutable version identities, never source bodies or
 credentials. Removing `.adt` only removes the optimization; source selection

--- a/packages/adt-flow/src/index.ts
+++ b/packages/adt-flow/src/index.ts
@@ -15,6 +15,7 @@ export {
   objectDescriptorSchema,
   ownedFileSchema,
   sourceSelectionSchema,
+  transportObjectInventoryEntrySchema,
   transportDescriptorSchema,
   type ObjectDescriptor,
   type OwnedFile,

--- a/packages/adt-flow/src/schemas.ts
+++ b/packages/adt-flow/src/schemas.ts
@@ -93,6 +93,16 @@ export const sourceSelectionSchema = z.object({
   sourceUri: z.string().min(1),
 });
 
+export const transportObjectInventoryEntrySchema = z.object({
+  pgmid: z.string().min(1),
+  type: z.string().min(1),
+  name: z.string().min(1),
+  wbtype: z.string().min(1).optional(),
+  uri: z.string().startsWith('/sap/bc/adt/').optional(),
+  objFunc: z.string(),
+  sourceTransport: z.string().min(1),
+});
+
 export const objectDescriptorSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -138,6 +148,7 @@ export const transportDescriptorSchema = z.object({
   schemaVersion: z.literal(1),
   requestedTransports: z.array(z.string().min(1)),
   scopeTransports: z.array(z.string().min(1)),
+  inventory: z.array(transportObjectInventoryEntrySchema).optional(),
   objects: z.array(z.string().min(1)),
   configDigest: z.string().regex(/^[a-f0-9]{64}$/),
   formatDigest: z.string().regex(/^[a-f0-9]{64}$/),

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -290,14 +290,14 @@ async function exactHeadFastPath(
     }
   | undefined
 > {
-  const transportPaths = transports.map(transportDescriptorPath);
-  const descriptors = await Promise.all(
-    transportPaths.map((path) =>
+  const requestedPaths = transports.map(transportDescriptorPath);
+  const requestedDescriptors = await Promise.all(
+    requestedPaths.map((path) =>
       readDescriptor(root, path, transportDescriptorSchema),
     ),
   );
   if (
-    descriptors.some(
+    requestedDescriptors.some(
       (descriptor) =>
         !descriptor ||
         descriptor.configDigest !== configDigest ||
@@ -309,6 +309,44 @@ async function exactHeadFastPath(
     return undefined;
   }
 
+  const initialDescriptors = requestedDescriptors as TransportDescriptor[];
+  const scopeTransports = initialDescriptors[0]?.scopeTransports;
+  if (
+    !scopeTransports ||
+    initialDescriptors.some(
+      (descriptor) =>
+        stableJson(descriptor.scopeTransports) !==
+          stableJson(scopeTransports) ||
+        transports.some(
+          (transport) => !descriptor.scopeTransports.includes(transport),
+        ),
+    )
+  ) {
+    return undefined;
+  }
+  const transportPaths = scopeTransports.map(transportDescriptorPath);
+  const descriptors = await Promise.all(
+    transportPaths.map((path) =>
+      readDescriptor(root, path, transportDescriptorSchema),
+    ),
+  );
+  if (
+    descriptors.some(
+      (descriptor, index) =>
+        !descriptor ||
+        descriptor.configDigest !== configDigest ||
+        descriptor.formatDigest !== formatDigest ||
+        descriptor.inventory === undefined ||
+        stableJson(descriptor.requestedTransports) !== stableJson(transports) ||
+        stableJson(descriptor.scopeTransports) !==
+          stableJson(scopeTransports) ||
+        descriptor.inventory.some(
+          (object) => object.sourceTransport !== scopeTransports[index],
+        ),
+    )
+  ) {
+    return undefined;
+  }
   const validDescriptors = descriptors as TransportDescriptor[];
   const objectPaths = [
     ...new Set(validDescriptors.flatMap((d) => d.objects)),
@@ -340,7 +378,7 @@ async function exactHeadFastPath(
   return {
     descriptorPaths: [...transportPaths, ...objectPaths].sort(compareStrings),
     ownedPaths: ownedPaths.sort(compareStrings),
-    scopeTransports: descriptors[0]?.scopeTransports ?? [...transports],
+    scopeTransports,
   };
 }
 
@@ -1222,10 +1260,17 @@ async function addTransportDescriptors(
     } catch {
       existing = undefined;
     }
+    const matchesCurrentCheckout =
+      existing !== undefined &&
+      stableJson(existing.requestedTransports) === stableJson(ctx.requested) &&
+      stableJson(existing.scopeTransports) ===
+        stableJson(manifest.scopeTransports);
+    const isPreviousSelfDescriptor =
+      existing?.requestedTransports.includes(transport) === true &&
+      existing.scopeTransports.includes(transport);
     if (
-      existing &&
-      existing.requestedTransports.includes(transport) &&
-      existing.scopeTransports.includes(transport)
+      existing?.scopeTransports.includes(transport) &&
+      (matchesCurrentCheckout || isPreviousSelfDescriptor)
     ) {
       ownedPaths.add(path);
       ownedOwners.set(path, 'flow-index');

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -155,6 +155,10 @@ function isUnsupportedEntry(entry: TransportSourceManifestEntry): boolean {
   );
 }
 
+function materializedObject(entry: TransportSourceManifestEntry) {
+  return entry.repositoryObject ?? entry.object;
+}
+
 function selectedVersion(
   entry: TransportSourceManifestEntry,
   mode: 'base' | 'head',
@@ -211,7 +215,7 @@ function groupEntries(entries: readonly TransportSourceManifestEntry[]): Array<{
     { identity: FlowObjectIdentity; entries: TransportSourceManifestEntry[] }
   >();
   for (const entry of entries) {
-    const identity = objectIdentity(entry.object);
+    const identity = objectIdentity(materializedObject(entry));
     const group = grouped.get(identity.canonical) ?? { identity, entries: [] };
     group.entries.push(entry);
     grouped.set(identity.canonical, group);
@@ -298,6 +302,7 @@ async function exactHeadFastPath(
         !descriptor ||
         descriptor.configDigest !== configDigest ||
         descriptor.formatDigest !== formatDigest ||
+        descriptor.inventory === undefined ||
         stableJson(descriptor.requestedTransports) !== stableJson(transports),
     )
   ) {
@@ -969,7 +974,7 @@ async function unsupportedEntries(
     { identity: FlowObjectIdentity; entries: TransportSourceManifestEntry[] }
   >();
   for (const entry of unsupported) {
-    const identity = objectIdentity(entry.object);
+    const identity = objectIdentity(materializedObject(entry));
     const existing = byIdentity.get(identity.canonical);
     if (existing) {
       existing.entries.push(entry);
@@ -1205,7 +1210,7 @@ async function addTransportDescriptors(
   const relevantObjectDescriptors = [...new Set(descriptorPaths)].sort(
     compareStrings,
   );
-  for (const transport of ctx.requested) {
+  for (const transport of manifest.scopeTransports) {
     const path = transportDescriptorPath(transport);
     let existing: TransportDescriptor | undefined;
     try {
@@ -1230,6 +1235,9 @@ async function addTransportDescriptors(
         schemaVersion: 1,
         requestedTransports: ctx.requested,
         scopeTransports: manifest.scopeTransports,
+        inventory: (manifest.inventory ?? []).filter(
+          (object) => object.sourceTransport === transport,
+        ),
         objects: relevantObjectDescriptors,
         configDigest: ctx.configDigest,
         formatDigest: ctx.formatDigest,

--- a/packages/adt-flow/tests/adt-client-adapter.test.ts
+++ b/packages/adt-flow/tests/adt-client-adapter.test.ts
@@ -17,6 +17,7 @@ const format = {
 const manifest: TransportSourceManifest = {
   requestedTransports: ['DEVK900001'],
   scopeTransports: ['DEVK900001'],
+  inventory: [],
   entries: [],
 };
 

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -41,6 +41,17 @@ function manifest(
   return {
     requestedTransports: [transport],
     scopeTransports: [transport],
+    inventory: [
+      {
+        pgmid: 'R3TR',
+        type: 'CLAS',
+        name: 'ZCL_SAMPLE',
+        wbtype: 'CLAS',
+        uri: '/sap/bc/adt/oo/classes/zcl_sample',
+        objFunc: '',
+        sourceTransport: transport,
+      },
+    ],
     entries: [
       {
         object: {
@@ -293,6 +304,53 @@ describe('transport checkout', () => {
         ).requestedTransports,
       ).toEqual(['DEVK900001', 'DEVK900002']);
     }
+  });
+
+  it('persists a complete CTS inventory in one descriptor per request and task', async () => {
+    const workspace = await root();
+    const current = manifest(
+      'modified',
+      version('before'),
+      version('after'),
+      'DEVK900002',
+    );
+    current.scopeTransports = ['DEVK900001', 'DEVK900002'];
+    current.inventory.push({
+      pgmid: 'LIMU',
+      type: 'ZZZZ',
+      name: 'ZUNSUPPORTED',
+      wbtype: 'ZZZZ',
+      uri: '/sap/bc/adt/repository/informationsystem/objectproperties/values',
+      objFunc: '',
+      sourceTransport: 'DEVK900002',
+    });
+    current.entries.push(unsupportedEntry('ZUNSUPPORTED'));
+
+    await createAdtFlowService(dependencies(() => current)).checkout({
+      root: workspace,
+      transports: ['DEVK900002'],
+      config,
+    });
+
+    const parent = JSON.parse(
+      await readFile(join(workspace, '.adt/tr/DEVK900001.json'), 'utf8'),
+    );
+    const task = JSON.parse(
+      await readFile(join(workspace, '.adt/tr/DEVK900002.json'), 'utf8'),
+    );
+    expect(parent.inventory).toEqual([]);
+    expect(task.inventory).toEqual([
+      expect.objectContaining({
+        type: 'CLAS',
+        name: 'ZCL_SAMPLE',
+        sourceTransport: 'DEVK900002',
+      }),
+      expect.objectContaining({
+        type: 'ZZZZ',
+        name: 'ZUNSUPPORTED',
+        sourceTransport: 'DEVK900002',
+      }),
+    ]);
   });
 
   it('does not overwrite an unrecognized file at a transport descriptor path', async () => {
@@ -768,6 +826,7 @@ describe('transport checkout', () => {
     const current: TransportSourceManifest = {
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001'],
+      inventory: [],
       entries: [unsupportedEntry()],
     };
     const ports = dependencies(() => current);
@@ -795,6 +854,7 @@ describe('transport checkout', () => {
     const current: TransportSourceManifest = {
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001'],
+      inventory: [],
       entries: [metadataLoadFailedEntry()],
     };
     const ports = dependencies(() => current);
@@ -822,6 +882,7 @@ describe('transport checkout', () => {
     const current: TransportSourceManifest = {
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001'],
+      inventory: [],
       entries: [unsupportedEntry()],
     };
     const ports = dependencies(() => current);

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -73,6 +73,7 @@ function manifest(
 
 function unsupportedEntry(
   name = 'PAYHX01',
+  sourceTransport = 'DEVK900001',
 ): TransportSourceManifest['entries'][number] {
   return {
     object: {
@@ -82,7 +83,7 @@ function unsupportedEntry(
       packageName: 'ZROOT_FEATURE',
     },
     component: { id: 'object' },
-    sourceTransport: 'DEVK900001',
+    sourceTransport,
     changeKind: 'unsupported',
     exact: false,
     diagnostic: {
@@ -324,7 +325,7 @@ describe('transport checkout', () => {
       objFunc: '',
       sourceTransport: 'DEVK900002',
     });
-    current.entries.push(unsupportedEntry('ZUNSUPPORTED'));
+    current.entries.push(unsupportedEntry('ZUNSUPPORTED', 'DEVK900002'));
 
     await createAdtFlowService(dependencies(() => current)).checkout({
       root: workspace,
@@ -351,6 +352,85 @@ describe('transport checkout', () => {
         sourceTransport: 'DEVK900002',
       }),
     ]);
+  });
+
+  it('rejects the exact-head fast path when a scoped descriptor is missing', async () => {
+    const workspace = await root();
+    const current = manifest(
+      'added',
+      undefined,
+      version('task-two'),
+      'DEVK900002',
+    );
+    current.scopeTransports = ['DEVK900001', 'DEVK900002'];
+    const ports = dependencies(() => current);
+    const flow = createAdtFlowService(ports);
+    await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900002'],
+      config,
+    });
+    await rm(join(workspace, '.adt/tr/DEVK900001.json'));
+    ports.buildManifest.mockClear();
+
+    const result = await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900002'],
+      config,
+    });
+
+    expect(result.fastPath).not.toBe('exact-head');
+    expect(ports.buildManifest).toHaveBeenCalledOnce();
+    await expect(
+      readFile(join(workspace, '.adt/tr/DEVK900001.json'), 'utf8'),
+    ).resolves.toContain('DEVK900001');
+  });
+
+  it('updates every scoped descriptor during a repeated task-only checkout', async () => {
+    const workspace = await root();
+    let current = manifest(
+      'added',
+      undefined,
+      version('task-two'),
+      'DEVK900002',
+    );
+    current.scopeTransports = ['DEVK900001', 'DEVK900002'];
+    const ports = dependencies(() => current);
+    const flow = createAdtFlowService(ports);
+    await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900002'],
+      config,
+    });
+
+    current = {
+      ...current,
+      entries: [
+        {
+          ...current.entries[0]!,
+          head: version('task-two-updated'),
+        },
+      ],
+    };
+    const taskDescriptorPath = join(workspace, '.adt/tr/DEVK900002.json');
+    const taskDescriptor = JSON.parse(
+      await readFile(taskDescriptorPath, 'utf8'),
+    );
+    taskDescriptor.configDigest = '0'.repeat(64);
+    await writeFile(taskDescriptorPath, JSON.stringify(taskDescriptor));
+
+    await expect(
+      flow.checkout({
+        root: workspace,
+        transports: ['DEVK900002'],
+        config,
+      }),
+    ).resolves.toMatchObject({ fastPath: 'none' });
+    for (const transport of ['DEVK900001', 'DEVK900002']) {
+      await expect(
+        readFile(join(workspace, `.adt/tr/${transport}.json`), 'utf8'),
+      ).resolves.toContain('DEVK900002');
+    }
   });
 
   it('does not overwrite an unrecognized file at a transport descriptor path', async () => {

--- a/packages/adt-mcp/src/lib/tools/cts-transport-source-manifest.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-transport-source-manifest.ts
@@ -36,6 +36,7 @@ type SourceManifestEntry = {
 type SourceManifestWithUris = {
   requestedTransports: unknown;
   scopeTransports: unknown;
+  inventory: ReadonlyArray<{ uri?: string; [key: string]: unknown }>;
   entries: readonly SourceManifestEntry[];
 };
 
@@ -63,6 +64,7 @@ export function toMcpTransportSourceManifest(
   return {
     requestedTransports: manifest.requestedTransports,
     scopeTransports: manifest.scopeTransports,
+    inventory: manifest.inventory.map(({ uri: _uri, ...entry }) => entry),
     entries: manifest.entries.map((entry) => {
       const {
         component: {

--- a/packages/adt-mcp/tests/transport-source-manifest-capabilities.test.ts
+++ b/packages/adt-mcp/tests/transport-source-manifest-capabilities.test.ts
@@ -12,6 +12,17 @@ test('a transport source manifest replaces every immutable source URI with a cap
     {
       requestedTransports: ['DEVK900001'],
       scopeTransports: ['DEVK900001'],
+      inventory: [
+        {
+          pgmid: 'LIMU',
+          type: 'METH',
+          name: 'ZCL_SAFE RUN',
+          wbtype: 'CLAS',
+          uri: '/sap/bc/adt/oo/classes/zcl_safe',
+          objFunc: '',
+          sourceTransport: 'DEVK900001',
+        },
+      ],
       entries: [
         {
           canonicalKey: 'CLAS:ZCL_SAFE',
@@ -41,6 +52,16 @@ test('a transport source manifest replaces every immutable source URI with a cap
 
   const encoded = JSON.stringify(response);
   assert.ok(!encoded.includes('/sap/bc/adt/'));
+  assert.deepEqual(response.inventory, [
+    {
+      pgmid: 'LIMU',
+      type: 'METH',
+      name: 'ZCL_SAFE RUN',
+      wbtype: 'CLAS',
+      objFunc: '',
+      sourceTransport: 'DEVK900001',
+    },
+  ]);
   const entry = response.entries[0]!;
   assert.match(entry.base!.sourceCapability, /^src_/u);
   assert.match(entry.head!.sourceCapability, /^src_/u);

--- a/packages/adt-server/src/request-handler.ts
+++ b/packages/adt-server/src/request-handler.ts
@@ -63,6 +63,7 @@ type RawSourceVersion = {
 export type RawTransportSourceManifest = {
   requestedTransports: unknown;
   scopeTransports: unknown;
+  inventory: ReadonlyArray<{ uri?: string; [key: string]: unknown }>;
   entries: ReadonlyArray<{
     component: {
       sourceUri?: string;
@@ -273,6 +274,7 @@ function toRestTransportSourceManifest(
   return {
     requestedTransports: manifest.requestedTransports,
     scopeTransports: manifest.scopeTransports,
+    inventory: manifest.inventory.map(({ uri: _uri, ...entry }) => entry),
     entries: manifest.entries.map((entry) => {
       const {
         component: {

--- a/packages/adt-server/src/rest-schemas.ts
+++ b/packages/adt-server/src/rest-schemas.ts
@@ -81,10 +81,23 @@ export const transportSourceManifestResponse = z
   .object({
     requestedTransports: z.array(z.string().trim().min(1).max(64)).min(1),
     scopeTransports: z.array(z.string().trim().min(1).max(64)).min(1),
+    inventory: z.array(
+      z
+        .object({
+          pgmid: z.string().trim().min(1).max(16),
+          type: z.string().trim().min(1).max(64),
+          name: z.string().trim().min(1).max(128),
+          wbtype: z.string().trim().min(1).max(64).optional(),
+          objFunc: z.string().max(16),
+          sourceTransport: z.string().trim().min(1).max(64),
+        })
+        .strict(),
+    ),
     entries: z.array(
       z
         .object({
           object: transportSourceManifestObject,
+          repositoryObject: transportSourceManifestObject.optional(),
           component: transportSourceManifestComponent,
           sourceTransport: z.string().trim().min(1).max(64),
           changeKind: z.enum([

--- a/packages/adt-server/tests/server.test.ts
+++ b/packages/adt-server/tests/server.test.ts
@@ -1277,6 +1277,17 @@ test('REST source reads redeem an opaque destination-bound manifest capability',
         return {
           requestedTransports: ['DEVK900001'],
           scopeTransports: ['DEVK900001'],
+          inventory: [
+            {
+              pgmid: 'LIMU',
+              type: 'METH',
+              name: 'ZCL_SAFE RUN',
+              wbtype: 'CLAS',
+              uri: '/sap/bc/adt/oo/classes/zcl_safe',
+              objFunc: '',
+              sourceTransport: 'DEVK900001',
+            },
+          ],
           entries: [
             {
               object: {
@@ -1342,10 +1353,21 @@ test('REST source reads redeem an opaque destination-bound manifest capability',
     );
     assert.strictEqual(manifestResponse.status, 200);
     const manifest = (await manifestResponse.json()) as {
+      inventory: Array<{ uri?: string; name: string }>;
       entries: Array<{ head?: { sourceCapability?: string } }>;
     };
     const encodedManifest = JSON.stringify(manifest);
     assert.ok(!encodedManifest.includes('/sap/bc/adt/'));
+    assert.deepStrictEqual(manifest.inventory, [
+      {
+        pgmid: 'LIMU',
+        type: 'METH',
+        name: 'ZCL_SAFE RUN',
+        wbtype: 'CLAS',
+        objFunc: '',
+        sourceTransport: 'DEVK900001',
+      },
+    ]);
     const sourceCapability = manifest.entries[0]?.head?.sourceCapability;
     assert.ok(sourceCapability);
 


### PR DESCRIPTION
## Summary

- retain every CTS object in a deterministic manifest inventory before source-format filtering
- write one .adt/tr/<TR>.json descriptor for every discovered request and task
- resolve supported LIMU leaves such as METH, CLSD, CPUB, and FUNC through their CLAS/FUGR repository owners while preserving original CTS identity
- expose URI-free inventory metadata through CLI, MCP, and REST boundaries

## Why

Unsupported transport entries currently disappear from source checkout state. A task that has no materializable source therefore cannot be identified and retried when support expands. Persisting the complete task-level inventory makes that state durable and allows later materialization without losing provenance.

## Validation

- ADK full suite passed
- adt-flow full suite passed
- adt-cli: 306 passed, 3 todo
- adt-mcp: 91 passed
- adt-server: 70 passed
- lint passed for adk, adt-flow, adt-cli, adt-mcp, and adt-server
- affected builds passed
- OpenSpec strict validation passed

## Notes

The adt-cli typecheck target still reports pre-existing errors in adt-plugin-abapgit and unrelated object-builder command types; adk and adt-flow typechecks pass, and all affected builds succeed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the complete CTS object inventory and write one deterministic `.adt/tr/<TR>.json` per discovered request/task; exact-head fast path now validates all scoped transport descriptors to avoid stale reuse.

- Resolves supported LIMU leaves (`METH`, `CLSD`, `CPUB`, `FUNC`) through their `CLAS`/`FUGR` repository owners while preserving the original CTS identity; entries may include `repositoryObject`, and grouping/deduplication use the repository owner.
- Adds `inventory` to the `adk` manifest and `adt-flow` transport descriptor; each descriptor keeps only its objects (`sourceTransport === <TR>`). CLI/`adt-mcp`/`adt-server` expose this inventory with SAP ADT URIs stripped. `@adt-flow` exports `transportObjectInventoryEntrySchema`; `transportDescriptorSchema.inventory` is optional in schema but required by the fast path.
- Exact-head fast path requires descriptors for every scoped transport with matching `requestedTransports`, `scopeTransports`, digests, and a present `inventory`; it also verifies each inventory entry’s `sourceTransport` matches its descriptor. Missing/mismatched descriptors fall back to a rebuild.
- `adt-flow` updates all scoped descriptors during task-only checkouts and reuses existing matching descriptors without overwrite.

- Migration:
  - Consumers of `adk`/`adt-flow` manifest data must handle `repositoryObject` and `inventory`.
  - Tools must handle multiple `.adt/tr/<TR>.json` descriptors per scope.
  - Do not depend on SAP ADT URIs in CLI/MCP/REST responses; they are removed.
  - First head checkout after upgrade may regenerate transport descriptors; exact-head fast path requires inventoryed scoped descriptors.

<sup>Written for commit 50eb8fe6bd7924d6ebccdb1cd09a3d4132b3410f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

