### PR TITLE
feat: expose typed CTS transport metadata

### DIFF
--- a/openspec/changes/add-cts-transport-metadata-json/design.md
+++ b/openspec/changes/add-cts-transport-metadata-json/design.md
@@ -1,0 +1,15 @@
+## Decision
+
+The ADT client continues to decode SAP's generated typed transport contract.
+`CtsTransportMetadataService` only projects that data; it performs no XML
+parsing and has no Commander or MCP concerns. CLI and MCP are thin adapters over
+the same service.
+
+`--json` writes exactly one JSON document to stdout. Diagnostics are written to
+stderr and failures set a non-zero exit status, so CI may parse stdout directly.
+
+## Boundaries
+
+The API is read-only. It does not release transports, select Git branches,
+merge changes, or encode SAP XML. A caller requesting a task receives the task
+as the primary unit; a caller requesting a request also receives its tasks.

--- a/openspec/changes/add-cts-transport-metadata-json/proposal.md
+++ b/openspec/changes/add-cts-transport-metadata-json/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Automation consumers need CTS release ordering and eligibility fields that the
+legacy transport summary omits. Reading raw `adt fetch` stdout is unsafe because
+the CLI renders progress UI there, and consumer-owned XML parsing duplicates SAP
+protocol handling.
+
+## What Changes
+
+- Add `adt cts tr metadata <transport> --json`, a stdout-clean typed metadata
+  projection for a request or task and its child tasks.
+- Add matching `cts_transport_metadata` MCP read tool.
+- Preserve number, parent, owner, description, status, type, and SAP
+  `lastchanged_timestamp` in a shared service result.
+
+## Impact
+
+Affected packages: `adt-client`, `adt-cli`, and `adt-mcp`. This is additive;
+existing commands remain unchanged. Consumers can migrate away from raw XML
+without credentials or consumer-specific SAP endpoint code.

--- a/openspec/changes/add-cts-transport-metadata-json/specs/cts-transport-metadata/spec.md
+++ b/openspec/changes/add-cts-transport-metadata-json/specs/cts-transport-metadata/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Typed transport metadata is available to automation
+
+The system SHALL expose a read-only typed projection of a CTS request or task
+that includes each returned unit's number, status, type, parent, owner,
+description, and SAP last-change timestamp when SAP provides it.
+
+#### Scenario: Request metadata includes child tasks
+
+- **WHEN** a caller requests metadata for a CTS request that contains tasks
+- **THEN** the result identifies the requested request and includes its request
+  unit and child task units
+
+### Requirement: CLI JSON stdout is machine-readable
+
+The `adt cts tr metadata <transport> --json` command SHALL write exactly one
+JSON document to stdout and SHALL write diagnostics only to stderr.
+
+#### Scenario: Successful JSON invocation
+
+- **WHEN** the command successfully reads a transport with `--json`
+- **THEN** stdout can be parsed directly as the typed metadata result
+
+### Requirement: MCP and CLI share metadata semantics
+
+The system SHALL expose an MCP `cts_transport_metadata` tool that uses the
+same metadata service as the CLI command.
+
+#### Scenario: Equivalent read through MCP
+
+- **WHEN** CLI and MCP query the same transport
+- **THEN** they return equivalent requested transport and CTS unit metadata

--- a/openspec/changes/add-cts-transport-metadata-json/tasks.md
+++ b/openspec/changes/add-cts-transport-metadata-json/tasks.md
@@ -1,0 +1,14 @@
+## 1. Typed CTS projection
+
+- [x] 1.1 Preserve parent, type, description, and last-change metadata in the client transport model.
+- [x] 1.2 Add a shared CTS metadata service with no XML or rendering logic.
+
+## 2. Delivery parity
+
+- [x] 2.1 Add the stdout-clean CLI JSON command and a focused command test.
+- [x] 2.2 Add the matching MCP tool and CLI/MCP parity test.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused package tests, typecheck, and strict OpenSpec validation.
+- [ ] 3.2 Prove the command against a disposable SAP transport before consumer promotion.

--- a/packages/adt-cli/src/index.ts
+++ b/packages/adt-cli/src/index.ts
@@ -73,6 +73,12 @@ export {
   type ListObjectVersionsResult,
 } from './lib/services/source-history';
 
+export {
+  CtsTransportMetadataService,
+  type CtsTransportMetadataResult,
+  type CtsTransportMetadataUnit,
+} from './lib/services/cts';
+
 // Source retrieval — shared by CLI and MCP for arc-1 SAPRead parity.
 export {
   getSource,

--- a/packages/adt-cli/src/lib/commands/cts/tr/index.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/index.ts
@@ -23,6 +23,7 @@ import { ctsDeleteCommand } from './delete';
 import { ctsReleaseCommand } from './release';
 import { ctsReassignCommand } from './reassign';
 import { ctsSourceManifestCommand } from './source-manifest';
+import { ctsTransportMetadataCommand } from './metadata';
 import { createTaskCommand } from './task';
 
 export function createTrCommand(): Command {
@@ -37,6 +38,7 @@ export function createTrCommand(): Command {
   trCmd.addCommand(ctsReleaseCommand);
   trCmd.addCommand(ctsReassignCommand);
   trCmd.addCommand(ctsSourceManifestCommand);
+  trCmd.addCommand(ctsTransportMetadataCommand);
   trCmd.addCommand(createTaskCommand());
   // NOTE: ctsCheckCommand not yet implemented (check endpoint not available)
 

--- a/packages/adt-cli/src/lib/commands/cts/tr/metadata.test.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/metadata.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdtClient } from '@abapify/adt-client';
+import {
+  createCtsTransportMetadataCommand,
+  type CtsTransportMetadataCommandDependencies,
+} from './metadata';
+
+describe('cts tr metadata', () => {
+  it('writes only the typed JSON result to stdout', async () => {
+    const lines: string[] = [];
+    const dependencies: Partial<CtsTransportMetadataCommandDependencies> = {
+      getClient: vi.fn(async () => ({}) as AdtClient),
+      createService: vi.fn(() => ({
+        get: vi.fn(async () => ({
+          requestedTransport: 'DEVK900001',
+          units: [
+            {
+              kind: 'request' as const,
+              number: 'DEVK900001',
+              status: 'R',
+              type: 'K',
+            },
+          ],
+        })),
+      })),
+      writeLine: (line) => lines.push(line),
+      writeError: vi.fn(),
+      setExitCode: vi.fn(),
+    };
+
+    await createCtsTransportMetadataCommand(dependencies).parseAsync(
+      ['devk900001', '--json'],
+      { from: 'user' },
+    );
+
+    expect(JSON.parse(lines[0] ?? '{}')).toEqual({
+      requestedTransport: 'DEVK900001',
+      units: [
+        { kind: 'request', number: 'DEVK900001', status: 'R', type: 'K' },
+      ],
+    });
+  });
+});

--- a/packages/adt-cli/src/lib/commands/cts/tr/metadata.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/metadata.ts
@@ -1,0 +1,58 @@
+import { Command } from 'commander';
+import { getAdtClientV2 } from '../../../utils/adt-client-v2';
+import { CtsTransportMetadataService } from '../../../services/cts';
+
+type AdtClient = Awaited<ReturnType<typeof getAdtClientV2>>;
+type MetadataServicePort = Pick<CtsTransportMetadataService, 'get'>;
+
+export interface CtsTransportMetadataCommandDependencies {
+  getClient: () => Promise<AdtClient>;
+  createService: (client: AdtClient) => MetadataServicePort;
+  writeLine: (content: string) => void;
+  writeError: (content: string) => void;
+  setExitCode: (code: number) => void;
+}
+
+const DEFAULT_DEPENDENCIES: CtsTransportMetadataCommandDependencies = {
+  getClient: getAdtClientV2,
+  createService: (client) => new CtsTransportMetadataService(client),
+  writeLine: (content) => console.log(content),
+  writeError: (content) => console.error(content),
+  setExitCode: (code) => {
+    process.exitCode = code;
+  },
+};
+
+/** Create a machine-readable CTS metadata command with no progress on stdout. */
+export function createCtsTransportMetadataCommand(
+  overrides: Partial<CtsTransportMetadataCommandDependencies> = {},
+): Command {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...overrides };
+  return new Command('metadata')
+    .description('Get typed CTS request/task metadata for automation')
+    .argument('<transport>', 'Transport request or task number')
+    .option('--json', 'Output metadata as JSON')
+    .action(async (transport: string, options: { json?: boolean }) => {
+      try {
+        const metadata = await dependencies
+          .createService(await dependencies.getClient())
+          .get(transport);
+        if (options.json) {
+          dependencies.writeLine(JSON.stringify(metadata, null, 2));
+          return;
+        }
+        for (const unit of metadata.units) {
+          dependencies.writeLine(
+            `${unit.kind} ${unit.number}: ${unit.status ?? 'unknown'} ${unit.type ?? ''}`.trim(),
+          );
+        }
+      } catch (error) {
+        dependencies.writeError(
+          `Transport metadata failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        dependencies.setExitCode(1);
+      }
+    });
+}
+
+export const ctsTransportMetadataCommand = createCtsTransportMetadataCommand();

--- a/packages/adt-cli/src/lib/services/cts/index.ts
+++ b/packages/adt-cli/src/lib/services/cts/index.ts
@@ -9,3 +9,8 @@ export {
   type ReleaseTransportInput,
   type ReleaseTransportResult,
 } from './transport-lifecycle';
+export {
+  CtsTransportMetadataService,
+  type CtsTransportMetadataResult,
+  type CtsTransportMetadataUnit,
+} from './transport-metadata';

--- a/packages/adt-cli/src/lib/services/cts/transport-metadata.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-metadata.ts
@@ -1,0 +1,56 @@
+import type { AdtClient } from '@abapify/adt-client';
+
+export interface CtsTransportMetadataUnit {
+  kind: 'request' | 'task';
+  number: string;
+  description?: string;
+  owner?: string;
+  status?: string;
+  type?: string;
+  parent?: string;
+  lastChangedTimestamp?: string;
+}
+
+export interface CtsTransportMetadataResult {
+  requestedTransport: string;
+  units: CtsTransportMetadataUnit[];
+}
+
+/**
+ * Typed CTS metadata projection shared by CLI and MCP. The ADT client owns
+ * protocol decoding; this service deliberately has no XML or console logic.
+ */
+export class CtsTransportMetadataService {
+  constructor(private readonly client: AdtClient) {}
+
+  async get(transport: string): Promise<CtsTransportMetadataResult> {
+    const requestedTransport = transport.trim().toUpperCase();
+    if (!requestedTransport)
+      throw new Error('Transport identifier is required');
+    const request =
+      await this.client.services.transports.get(requestedTransport);
+    const units: CtsTransportMetadataUnit[] = [
+      {
+        kind: request.parent ? 'task' : 'request',
+        number: request.number,
+        description: request.desc,
+        owner: request.owner,
+        status: request.status,
+        type: request.type,
+        parent: request.parent,
+        lastChangedTimestamp: request.lastChangedTimestamp,
+      },
+      ...(request.tasks ?? []).map((task) => ({
+        kind: 'task' as const,
+        number: task.number,
+        description: task.desc,
+        owner: task.owner,
+        status: task.status,
+        type: task.type,
+        parent: task.parent || request.number,
+        lastChangedTimestamp: task.lastChangedTimestamp,
+      })),
+    ];
+    return { requestedTransport, units };
+  }
+}

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -140,6 +140,35 @@ describe('parity: cts', () => {
     expect(mcp.json).toEqual(cliMetadata);
   });
 
+  it('transport metadata for a task returns the task, not its parent request', async () => {
+    // SAP returns the parent request and the requested task as siblings;
+    // metadata must project the task (DEVK900002), not the parent (DEVK900001).
+    const cli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'metadata',
+      'DEVK900002',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    const cliMetadata = extractJson<{
+      requestedTransport: string;
+      units: Array<{ number: string; kind: string }>;
+    }>(cli);
+    expect(cliMetadata?.requestedTransport).toBe('DEVK900002');
+    expect(cliMetadata?.units).toHaveLength(1);
+    expect(cliMetadata?.units[0]?.number).toBe('DEVK900002');
+    expect(cliMetadata?.units[0]?.kind).toBe('task');
+
+    const mcp = await callMcpTool<{
+      requestedTransport: string;
+      units: Array<{ number: string; kind: string }>;
+    }>(harness, 'cts_transport_metadata', { transport: 'DEVK900002' });
+    expect(mcp.isError).toBe(false);
+    expect(mcp.json).toEqual(cliMetadata);
+    expect(mcp.json.units[0]?.number).toBe('DEVK900002');
+  });
+
   // ──────────────────────────────────────────────────────────────────────────
   // 3. Create transport (CLI + MCP parity)
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -117,6 +117,29 @@ describe('parity: cts', () => {
     expect(JSON.stringify(mcp.json)).toContain('DEVK900001');
   });
 
+  it('transport metadata: CLI JSON and MCP return the same CTS unit', async () => {
+    const cli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'metadata',
+      'DEVK900001',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    const cliMetadata = extractJson<{
+      requestedTransport: string;
+      units: Array<{ number: string }>;
+    }>(cli);
+    expect(cliMetadata?.requestedTransport).toBe('DEVK900001');
+
+    const mcp = await callMcpTool<{
+      requestedTransport: string;
+      units: Array<{ number: string }>;
+    }>(harness, 'cts_transport_metadata', { transport: 'DEVK900001' });
+    expect(mcp.isError).toBe(false);
+    expect(mcp.json).toEqual(cliMetadata);
+  });
+
   // ──────────────────────────────────────────────────────────────────────────
   // 3. Create transport (CLI + MCP parity)
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/adt-client/src/services/transports.ts
+++ b/packages/adt-client/src/services/transports.ts
@@ -88,7 +88,14 @@ export class TransportService {
       data?.root && typeof data.root === 'object'
         ? (data.root as Record<string, unknown>)
         : data;
+    // SAP returns the parent request and the requested task as siblings
+    // (e.g. GET .../DEVK900002 yields root.request=DEVK900001 and
+    // root.task=DEVK900002). Prefer the unit whose number matches the
+    // requested trkorr so a task fetch does not map its parent request.
+    const wanted = trkorr.trim().toUpperCase();
     const request =
+      this.findUnit(unwrapped?.task, wanted) ??
+      this.findUnit(unwrapped?.request, wanted) ??
       (unwrapped?.request as Record<string, unknown> | undefined) ??
       (unwrapped?.task as Record<string, unknown> | undefined) ??
       unwrapped;
@@ -127,6 +134,22 @@ export class TransportService {
   async release(_trkorr: string): Promise<void> {
     // NOTE: Release action not yet implemented via service layer
     throw new Error('Transport release via service layer not yet implemented.');
+  }
+
+  /**
+   * Find a request/task unit whose number matches the wanted transport id.
+   * Handles both single-object and array shapes from ts-xsd.
+   */
+  private findUnit(
+    node: unknown,
+    wanted: string,
+  ): Record<string, unknown> | undefined {
+    if (!node) return undefined;
+    const arr = Array.isArray(node) ? node : [node];
+    return arr.find((item) => {
+      const u = item as Record<string, unknown>;
+      return String(u?.trkorr ?? u?.number ?? '').toUpperCase() === wanted;
+    }) as Record<string, unknown> | undefined;
   }
 
   /**

--- a/packages/adt-client/src/services/transports.ts
+++ b/packages/adt-client/src/services/transports.ts
@@ -20,13 +20,19 @@ export interface Transport {
   status?: string;
   type?: string;
   target?: string;
+  parent?: string;
+  lastChangedTimestamp?: string;
   tasks?: TransportTask[];
 }
 
 export interface TransportTask {
   number: string;
+  desc?: string;
   owner?: string;
   status?: string;
+  type?: string;
+  parent?: string;
+  lastChangedTimestamp?: string;
 }
 
 /**
@@ -83,7 +89,9 @@ export class TransportService {
         ? (data.root as Record<string, unknown>)
         : data;
     const request =
-      (unwrapped?.request as Record<string, unknown> | undefined) ?? unwrapped;
+      (unwrapped?.request as Record<string, unknown> | undefined) ??
+      (unwrapped?.task as Record<string, unknown> | undefined) ??
+      unwrapped;
     return this.mapToTransport(request);
   }
 
@@ -179,6 +187,10 @@ export class TransportService {
       target:
         (data.tarsystem as string | undefined) ??
         (data.target as string | undefined),
+      parent: data.parent as string | undefined,
+      lastChangedTimestamp:
+        (data.lastchanged_timestamp as string | undefined) ??
+        (data.lastChangedTimestamp as string | undefined),
       tasks: this.extractTasks(data),
     };
   }
@@ -206,6 +218,15 @@ export class TransportService {
         status:
           (t.trstatus as string | undefined) ??
           (t.status as string | undefined),
+        desc:
+          (t.as4text as string | undefined) ?? (t.desc as string | undefined),
+        type:
+          (t.trfunction as string | undefined) ??
+          (t.type as string | undefined),
+        parent: t.parent as string | undefined,
+        lastChangedTimestamp:
+          (t.lastchanged_timestamp as string | undefined) ??
+          (t.lastChangedTimestamp as string | undefined),
       };
     });
   }

--- a/packages/adt-mcp/src/lib/tools/cts-transport-metadata.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-transport-metadata.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CtsTransportMetadataService } from '@abapify/adt-cli';
+import type { ToolContext } from '../types';
+import { sessionOrConnectionShape } from './shared-schemas';
+import { resolveClient } from './session-helpers';
+
+/** Register the typed CTS metadata projection shared with `adt cts tr metadata`. */
+export function registerCtsTransportMetadataTool(
+  server: McpServer,
+  ctx: ToolContext,
+): void {
+  server.tool(
+    'cts_transport_metadata',
+    'Get typed request/task metadata including CTS status, parent, type, and last-change timestamp.',
+    {
+      ...sessionOrConnectionShape,
+      transport: z
+        .string()
+        .trim()
+        .min(1)
+        .describe('Transport request or task number'),
+    },
+    async (args, extra) => {
+      try {
+        const { client } = await resolveClient(ctx, args, extra ?? {});
+        const metadata = await new CtsTransportMetadataService(client).get(
+          args.transport,
+        );
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(metadata, null, 2) },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Transport metadata failed: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/packages/adt-mcp/src/lib/tools/index.ts
+++ b/packages/adt-mcp/src/lib/tools/index.ts
@@ -16,6 +16,7 @@ import { registerSearchObjectsTool } from './search-objects';
 import { registerGetObjectTool } from './get-object';
 import { registerCtsListTransportsTool } from './cts-list-transports';
 import { registerCtsGetTransportTool } from './cts-get-transport';
+import { registerCtsTransportMetadataTool } from './cts-transport-metadata';
 import { registerCtsCreateTransportTool } from './cts-create-transport';
 import { registerCtsCreateTaskTool } from './cts-create-task';
 import { registerCtsReleaseTransportTool } from './cts-release-transport';
@@ -141,6 +142,7 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
   registerGetObjectTool(server, ctx);
   registerCtsListTransportsTool(server, ctx);
   registerCtsGetTransportTool(server, ctx);
+  registerCtsTransportMetadataTool(server, ctx);
   registerCtsCreateTransportTool(server, ctx);
   registerCtsCreateTaskTool(server, ctx);
   registerCtsReleaseTransportTool(server, ctx);

--- a/packages/adt-mcp/tests/integration.test.ts
+++ b/packages/adt-mcp/tests/integration.test.ts
@@ -210,6 +210,21 @@ describe('adt-mcp integration tests', () => {
     });
   });
 
+  describe('cts_transport_metadata tool', () => {
+    it('returns typed CTS metadata', async () => {
+      const { json } = await callTool('cts_transport_metadata', {
+        ...connArgs(),
+        transport: 'DEVK900001',
+      });
+      const data = json as {
+        requestedTransport: string;
+        units: Array<{ number: string }>;
+      };
+      assert.strictEqual(data.requestedTransport, 'DEVK900001');
+      assert.ok(data.units.some((unit) => unit.number === 'DEVK900001'));
+    });
+  });
+
   // ── cts_delete_transport ───────────────────────────────────────
 
   describe('cts_delete_transport tool', () => {


### PR DESCRIPTION
## Why

Automation consumers need CTS release ordering and eligibility fields that the legacy transport summary omits. Raw fetch output can contain human progress UI, so consumers must not parse it as provider data.

## Change

- Adds `adt cts tr metadata <transport> --json`: exactly one JSON document on stdout.
- Adds matching `cts_transport_metadata` MCP tool.
- Projects typed SAP request/task fields: number, parent, owner, description, status, type, and last-change timestamp.
- No manual XML parser or consumer-specific SAP endpoint.

## Verification

- Focused command test: pass.
- CLI/MCP parity: 17 tests pass.
- MCP integration: 92 tests pass.
- OpenSpec strict validation: pass.
- Repository typecheck remains blocked by existing unrelated ADK/CDS baseline errors; no diagnostics reference this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CTS transport metadata command with JSON output for requests and tasks.
  * Added the `cts_transport_metadata` MCP tool with matching results.
  * Metadata includes number, status, type, parent, owner, description, and last-change timestamp.
  * JSON output is cleanly written to stdout, while diagnostics are sent to stderr.
* **Bug Fixes**
  * Improved transport and task matching when retrieving metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->