### PR TITLE
fix: resolve R3TR function modules via function groups

### DIFF
--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -666,13 +666,27 @@ function repositoryNameFromUri(
   }
 }
 
-/** Resolve a LIMU leaf to the repository object that owns its source. */
+/** Resolve a CTS object to the repository object that owns its source. */
 function repositoryObjectReference(
   reference: TransportObjectReference,
 ): RepositoryObjectReference {
   const pgmid = reference.pgmid.trim().toUpperCase();
   const rawTypeFull = reference.type.trim().toUpperCase();
   const rawType = rawTypeFull.split('/')[0] ?? '';
+  // Some SAP releases expose a function-module change as R3TR/FUNC rather
+  // than LIMU/FUNC. Function-module source history belongs to its function
+  // group, whose identity is supplied by the ADT URI.
+  if (rawType === 'FUNC') {
+    const ownerName = repositoryNameFromUri(reference.uri, 'FUGR');
+    if (ownerName) {
+      return {
+        pgmid: 'R3TR',
+        type: 'FUGR',
+        name: ownerName,
+        isDeleted: false,
+      };
+    }
+  }
   if (pgmid === 'LIMU') {
     const ownerType = reference.wbtype?.trim().toUpperCase();
     const ownerName = ownerType

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -666,6 +666,68 @@ function repositoryNameFromUri(
   }
 }
 
+// Some SAP releases expose a function-module change as R3TR/FUNC rather
+// than LIMU/FUNC. Function-module source history belongs to its function
+// group, whose identity is supplied by the ADT URI.
+function resolveFuncGroupReference(
+  reference: TransportObjectReference,
+  rawType: string,
+): RepositoryObjectReference | undefined {
+  if (rawType !== 'FUNC') return undefined;
+  const ownerName = repositoryNameFromUri(reference.uri, 'FUGR');
+  if (!ownerName) return undefined;
+  return {
+    pgmid: 'R3TR',
+    type: 'FUGR',
+    name: ownerName,
+    isDeleted: false,
+  };
+}
+
+function resolveLimuReference(
+  reference: TransportObjectReference,
+  pgmid: string,
+  rawType: string,
+): RepositoryObjectReference | undefined {
+  if (pgmid !== 'LIMU') return undefined;
+  const ownerType = reference.wbtype?.trim().toUpperCase();
+  const ownerName = ownerType
+    ? repositoryNameFromUri(reference.uri, ownerType)
+    : undefined;
+  if (ownerType && ownerName) {
+    return {
+      pgmid: 'R3TR',
+      type: ownerType,
+      name: ownerName,
+      // A deleted leaf changes its owner. Only REPS preserves the legacy
+      // whole-program deletion behavior when no R3TR parent is present.
+      isDeleted: rawType === 'REPS' && reference.isDeleted,
+    };
+  }
+  if (rawType === 'REPS') {
+    return {
+      pgmid: 'R3TR',
+      type: 'PROG',
+      name: reference.name.trim().toUpperCase(),
+      isDeleted: reference.isDeleted,
+    };
+  }
+  return undefined;
+}
+
+function fallbackReference(
+  reference: TransportObjectReference,
+  pgmid: string,
+  rawTypeFull: string,
+): RepositoryObjectReference {
+  return {
+    pgmid,
+    type: rawTypeFull,
+    name: reference.name.trim().toUpperCase(),
+    isDeleted: reference.isDeleted,
+  };
+}
+
 /** Resolve a CTS object to the repository object that owns its source. */
 function repositoryObjectReference(
   reference: TransportObjectReference,
@@ -673,50 +735,11 @@ function repositoryObjectReference(
   const pgmid = reference.pgmid.trim().toUpperCase();
   const rawTypeFull = reference.type.trim().toUpperCase();
   const rawType = rawTypeFull.split('/')[0] ?? '';
-  // Some SAP releases expose a function-module change as R3TR/FUNC rather
-  // than LIMU/FUNC. Function-module source history belongs to its function
-  // group, whose identity is supplied by the ADT URI.
-  if (rawType === 'FUNC') {
-    const ownerName = repositoryNameFromUri(reference.uri, 'FUGR');
-    if (ownerName) {
-      return {
-        pgmid: 'R3TR',
-        type: 'FUGR',
-        name: ownerName,
-        isDeleted: false,
-      };
-    }
-  }
-  if (pgmid === 'LIMU') {
-    const ownerType = reference.wbtype?.trim().toUpperCase();
-    const ownerName = ownerType
-      ? repositoryNameFromUri(reference.uri, ownerType)
-      : undefined;
-    if (ownerType && ownerName) {
-      return {
-        pgmid: 'R3TR',
-        type: ownerType,
-        name: ownerName,
-        // A deleted leaf changes its owner. Only REPS preserves the legacy
-        // whole-program deletion behavior when no R3TR parent is present.
-        isDeleted: rawType === 'REPS' && reference.isDeleted,
-      };
-    }
-    if (rawType === 'REPS') {
-      return {
-        pgmid: 'R3TR',
-        type: 'PROG',
-        name: reference.name.trim().toUpperCase(),
-        isDeleted: reference.isDeleted,
-      };
-    }
-  }
-  return {
-    pgmid,
-    type: rawTypeFull,
-    name: reference.name.trim().toUpperCase(),
-    isDeleted: reference.isDeleted,
-  };
+  return (
+    resolveFuncGroupReference(reference, rawType) ??
+    resolveLimuReference(reference, pgmid, rawType) ??
+    fallbackReference(reference, pgmid, rawTypeFull)
+  );
 }
 
 function selectorValues(value: string | string[] | undefined): string[] {

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -838,6 +838,51 @@ describe('buildTransportSourceManifest', () => {
     );
   });
 
+  it('canonicalizes an R3TR function module to its owning function group', async () => {
+    const functionModule = transportObject({
+      name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+      type: 'FUNC',
+      objectUri:
+        '/sap/bc/adt/functions/groups/zfg_py_lean/fmodules/zfm_py_lean_paymedium_event_21',
+      factoryName: 'ZFG_PY_LEAN',
+      metadata: rootSourceMetadata(),
+    });
+    mockResolution([functionModule], ['DEVK900003'], ['DEVK900003']);
+    const { ctx } = contextWithVersions(
+      vi
+        .fn()
+        .mockResolvedValue([
+          version('00002', 0, ['DEVK900003']),
+          version('00001', 1, ['DEVK800001']),
+        ]),
+    );
+
+    const manifest = await buildTransportSourceManifest(
+      ['DEVK900003'],
+      {},
+      ctx,
+    );
+
+    expect(factoryGet).toHaveBeenCalledWith('ZFG_PY_LEAN', 'FUGR');
+    expect(manifest.entries).toEqual([
+      expect.objectContaining({
+        object: {
+          pgmid: 'R3TR',
+          type: 'FUNC',
+          name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+          packageName: 'ZPACKAGE',
+        },
+        repositoryObject: {
+          pgmid: 'R3TR',
+          type: 'FUGR',
+          name: 'ZFG_PY_LEAN',
+          packageName: 'ZPACKAGE',
+        },
+        exact: true,
+      }),
+    ]);
+  });
+
   it('ignores R3TR SUSK authorization-maintenance assignments as non-source entries', async () => {
     const authorizationAssignment = transportObject({
       name: 'Z_CONCUR_RECON',


### PR DESCRIPTION
## Summary

Some SAP releases report function-module transport changes as `R3TR/FUNC`. Function modules are children of a function group, so source history must resolve the owning `R3TR/FUGR` from the ADT URI before loading metadata.

This change preserves the original CTS object identity in the manifest and resolves its repository object to the owning function group. A deleted individual function module remains an owner change, not deletion of the full function group.

## Verification

- `transport-source-manifest.test.ts`: 32 passing tests, including a new `R3TR/FUNC` regression.
- `nx build adk`: passed.
- `nx lint adk`: passed.
- Prettier check and `git diff --check`: passed.

## Known baseline

`nx typecheck adk` currently fails on unrelated existing ADK model type errors (CDS/factory/FUGR), including files outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes R3TR function-module transport changes so source history resolves them to their owning function group.

Some SAP releases expose function-module changes as `R3TR/FUNC`. The manifest now preserves the original `R3TR/FUNC` identity but resolves its repository object to the owning `R3TR/FUGR` derived from the ADT URI. A deleted individual function module remains an owner change and does not delete the whole function group.

**Refactors**
- Flattened the repository-object resolution into dedicated helpers with no behavior change.

<sup>Written for commit 194590b186d19f6c3cb63cadf5f325ff10dda77e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Function module transport references are now correctly associated with their owning function group when the group can be identified.
  * Transport source manifests preserve the original change object while exposing the canonical function group repository reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->