### PR TITLE
fix(adk): resolve LIMU function module owners

### DIFF
--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -699,21 +699,27 @@ async function resolveFuncGroupBySearch(
       (await context.client.adt.repository.informationsystem.search.quickSearch(
         { query: reference.name, maxResults: 10 },
       )) as Record<string, unknown>;
+    // The quick-search response may nest references under
+    // `objectReferences` or `mainObject`, or expose a top-level
+    // `objectReference`. Accept all three shapes.
     const container =
       asRecord(result['objectReferences']) ?? asRecord(result['mainObject']);
-    const raw = container?.['objectReference'];
+    const raw = container?.['objectReference'] ?? result['objectReference'];
     const matches = (Array.isArray(raw) ? raw : [raw])
       .map(asRecord)
       .filter((item): item is Record<string, unknown> => Boolean(item));
-    const match = matches.find(
-      (item) =>
-        nonEmptyString(item['name'])?.toUpperCase() ===
-        reference.name.trim().toUpperCase(),
-    );
-    const ownerName = repositoryNameFromUri(
-      nonEmptyString(match?.['uri']),
-      'FUGR',
-    );
+    // Match by exact function-module name, then pick the first result
+    // whose URI resolves to a FUGR owner. This avoids a same-named
+    // non-FUGR object (e.g. FUGR/F) masking the valid function-group
+    // result when it appears earlier in the response.
+    const ownerName = matches
+      .filter(
+        (item) =>
+          nonEmptyString(item['name'])?.toUpperCase() ===
+          reference.name.trim().toUpperCase(),
+      )
+      .map((item) => repositoryNameFromUri(nonEmptyString(item['uri']), 'FUGR'))
+      .find((name): name is string => Boolean(name));
     return ownerName
       ? { pgmid: 'R3TR', type: 'FUGR', name: ownerName, isDeleted: false }
       : undefined;
@@ -770,7 +776,7 @@ function fallbackReference(
 async function repositoryObjectReference(
   reference: TransportObjectReference,
   context: AdkContext,
-): RepositoryObjectReference {
+): Promise<RepositoryObjectReference> {
   const pgmid = reference.pgmid.trim().toUpperCase();
   const rawTypeFull = reference.type.trim().toUpperCase();
   const rawType = rawTypeFull.split('/')[0] ?? '';

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -684,6 +684,44 @@ function resolveFuncGroupReference(
   };
 }
 
+async function resolveFuncGroupBySearch(
+  reference: TransportObjectReference,
+  context: AdkContext,
+): Promise<RepositoryObjectReference | undefined> {
+  if (
+    reference.pgmid.trim().toUpperCase() !== 'LIMU' ||
+    reference.type.trim().toUpperCase() !== 'FUNC' ||
+    reference.wbtype?.trim().toUpperCase().split('/')[0] !== 'FUGR'
+  )
+    return undefined;
+  try {
+    const result =
+      (await context.client.adt.repository.informationsystem.search.quickSearch(
+        { query: reference.name, maxResults: 10 },
+      )) as Record<string, unknown>;
+    const container =
+      asRecord(result['objectReferences']) ?? asRecord(result['mainObject']);
+    const raw = container?.['objectReference'];
+    const matches = (Array.isArray(raw) ? raw : [raw])
+      .map(asRecord)
+      .filter((item): item is Record<string, unknown> => Boolean(item));
+    const match = matches.find(
+      (item) =>
+        nonEmptyString(item['name'])?.toUpperCase() ===
+        reference.name.trim().toUpperCase(),
+    );
+    const ownerName = repositoryNameFromUri(
+      nonEmptyString(match?.['uri']),
+      'FUGR',
+    );
+    return ownerName
+      ? { pgmid: 'R3TR', type: 'FUGR', name: ownerName, isDeleted: false }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveLimuReference(
   reference: TransportObjectReference,
   pgmid: string,
@@ -729,14 +767,16 @@ function fallbackReference(
 }
 
 /** Resolve a CTS object to the repository object that owns its source. */
-function repositoryObjectReference(
+async function repositoryObjectReference(
   reference: TransportObjectReference,
+  context: AdkContext,
 ): RepositoryObjectReference {
   const pgmid = reference.pgmid.trim().toUpperCase();
   const rawTypeFull = reference.type.trim().toUpperCase();
   const rawType = rawTypeFull.split('/')[0] ?? '';
   return (
     resolveFuncGroupReference(reference, rawType) ??
+    (await resolveFuncGroupBySearch(reference, context)) ??
     resolveLimuReference(reference, pgmid, rawType) ??
     fallbackReference(reference, pgmid, rawTypeFull)
   );
@@ -1071,14 +1111,18 @@ export async function buildTransportSourceManifest(
         compareText(left.name, right.name),
     );
   const seenRepositoryObjects = new Set<string>();
-  const objects = resolved.objects
-    .filter((reference) => !isNonSourceCtsObject(reference))
-    .map((original) => ({
-      original,
-      repository: repositoryObjectReference(original),
-      sourceTransport:
-        resolved.sourceTransportMap.get(original.key) ?? requested[0] ?? '',
-    }))
+  const objects = (
+    await mapOrdered(
+      resolved.objects.filter((reference) => !isNonSourceCtsObject(reference)),
+      normalizeConcurrency(options.concurrency),
+      async (original) => ({
+        original,
+        repository: await repositoryObjectReference(original, context),
+        sourceTransport:
+          resolved.sourceTransportMap.get(original.key) ?? requested[0] ?? '',
+      }),
+    )
+  )
     .filter(({ original, repository }) =>
       manifestSelectorMatches(original, repository, options.selector),
     )

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -118,15 +118,17 @@ function contextWithVersions(
   listVersions: (versionsUri: string) => Promise<SourceVersionRef[]>,
 ) {
   const readVersionSource = vi.fn();
+  const quickSearch = vi.fn();
   const ctx = {
     client: {
+      adt: { repository: { informationsystem: { search: { quickSearch } } } },
       services: {
         sourceHistory: { listVersions, readVersionSource },
       },
     },
   } as unknown as AdkContext;
 
-  return { ctx, readVersionSource };
+  return { ctx, readVersionSource, quickSearch };
 }
 
 describe('selectTransportSourceVersions', () => {
@@ -881,6 +883,32 @@ describe('buildTransportSourceManifest', () => {
         exact: true,
       }),
     ]);
+  });
+
+  it('resolves real LIMU FUNC FUGR/FF inventory through its searched group URI', async () => {
+    const functionModule = transportObject({
+      name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+      pgmid: 'LIMU',
+      type: 'FUNC',
+      wbtype: 'FUGR/FF',
+      objectUri: '',
+      factoryName: 'ZFG_PY_LEAN',
+      metadata: rootSourceMetadata(),
+    });
+    mockResolution([functionModule], ['S0DK955760'], ['S0DK955760']);
+    const { ctx, quickSearch } = contextWithVersions(
+      vi.fn().mockResolvedValue([version('00001', 0, ['S0DK955760'])]),
+    );
+    quickSearch.mockResolvedValue({
+      objectReferences: {
+        objectReference: {
+          name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+          uri: '/sap/bc/adt/functions/groups/zfg_py_lean/fmodules/zfm_py_lean_paymedium_event_21',
+        },
+      },
+    });
+    await buildTransportSourceManifest(['S0DK955760'], {}, ctx);
+    expect(factoryGet).toHaveBeenCalledWith('ZFG_PY_LEAN', 'FUGR');
   });
 
   it('ignores R3TR SUSK authorization-maintenance assignments as non-source entries', async () => {

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -899,16 +899,48 @@ describe('buildTransportSourceManifest', () => {
     const { ctx, quickSearch } = contextWithVersions(
       vi.fn().mockResolvedValue([version('00001', 0, ['S0DK955760'])]),
     );
+    // A same-named non-FUGR result (e.g. a program) appears before the
+    // valid function-module result. The resolver must skip the non-FUGR
+    // URI and select the function-module URI whose path resolves to the
+    // owning function group.
     quickSearch.mockResolvedValue({
       objectReferences: {
-        objectReference: {
-          name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
-          uri: '/sap/bc/adt/functions/groups/zfg_py_lean/fmodules/zfm_py_lean_paymedium_event_21',
-        },
+        objectReference: [
+          {
+            name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+            uri: '/sap/bc/adt/programs/zfm_py_lean_paymedium_event_21',
+          },
+          {
+            name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+            uri: '/sap/bc/adt/functions/groups/zfg_py_lean/fmodules/zfm_py_lean_paymedium_event_21',
+          },
+        ],
       },
     });
-    await buildTransportSourceManifest(['S0DK955760'], {}, ctx);
+    const manifest = await buildTransportSourceManifest(
+      ['S0DK955760'],
+      {},
+      ctx,
+    );
+    expect(quickSearch).toHaveBeenCalledWith({
+      query: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+      maxResults: 10,
+    });
     expect(factoryGet).toHaveBeenCalledWith('ZFG_PY_LEAN', 'FUGR');
+    expect(manifest.entries).toEqual([
+      expect.objectContaining({
+        object: expect.objectContaining({
+          pgmid: 'LIMU',
+          type: 'FUNC',
+          name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+        }),
+        repositoryObject: expect.objectContaining({
+          pgmid: 'R3TR',
+          type: 'FUGR',
+          name: 'ZFG_PY_LEAN',
+        }),
+      }),
+    ]);
   });
 
   it('ignores R3TR SUSK authorization-maintenance assignments as non-source entries', async () => {


### PR DESCRIPTION
## **User description**
Resolves LIMU/FUNC transport entries whose CTS inventory identifies the owner as FUGR/FF but omits a group URI. Uses repository quick search only for that shape, validates the returned function-group URI, and materializes the owning FUGR. Adds a regression test for the real CTS shape.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes LIMU function module transport entries whose CTS inventory names a FUGR/FF owner without a group URI, so `buildTransportSourceManifest` now resolves the owning function group via repository quick search and materializes it in the manifest.

- Quick search runs only for LIMU/FUNC entries with FUGR workbench type, and results are filtered to URIs that resolve to a FUGR so a same-named non-FUGR object can't mask the owner.
- `repositoryObjectReference` is now async and runs under the configured concurrency limit.
- Adds a regression test covering the real CTS inventory shape, including the same-name collision case.

<sup>Written for commit 242c9d5c28e337d27d0c51c82d243f97ee5ce524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of function-module references when the owning function group is not directly identified.
  * Added support for asynchronously finding the correct function group through ADT search, including cases with multiple matching results.
  * Ensured manifest generation handles these references reliably while preserving result order and selecting the appropriate function-group result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Resolve function module owners when transport data omits the function-group URI

### What Changed
- LIMU function modules with `FUGR/FF` ownership are now linked to their owning function group through repository search when the transport entry lacks a group URI
- Search results require an exact function-module name and a valid function-group URI, so earlier same-named non-function-group results no longer hide the correct owner
- Supports the repository search response shapes used by the service and continues safely when no valid owner is found
- Added regression coverage for the real CTS inventory format and same-name search collisions

### Impact
`✅ Correct function-group ownership in transport manifests`
`✅ Reliable handling of incomplete CTS owner data`
`✅ Fewer incorrect repository-object matches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
