### PR TITLE
Fix/limu func source history

### DIFF
--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -904,8 +904,8 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
           ...entry,
           repositoryObject: {
             pgmid: repository.pgmid,
-            type: repository.type,
-            name: repository.name,
+            type: repository.functionGroupName ? 'FUGR' : repository.type,
+            name: repository.functionGroupName ?? repository.name,
             ...(packageName ? { packageName } : {}),
           },
         }

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -3,6 +3,7 @@ import type { AdkContext } from './base/context';
 import { getGlobalContext } from './base/global-context';
 import { getEndpointForType, normalizeObjectName } from './base/registry';
 import { createAdkFactory } from './factory';
+import { AdkFunctionModule } from './objects/repository/fugr';
 import {
   resolveTransportObjects,
   type ResolvedTransportObjects,
@@ -405,13 +406,27 @@ async function discoverObjectSourceHistory(
   objectType: string,
   ctx: AdkContext,
   normalizeIdentity = true,
+  functionGroupName?: string,
 ): Promise<ObjectSourceDiscovery> {
   const object = normalizeIdentity
     ? normalizeSourceHistoryIdentity(objectName, objectType)
     : { name: objectName, type: objectType };
-  const model = createAdkFactory(ctx).get(object.name, object.type);
-  const load = ensureObjectLoadable(asRecord(model), object);
-  await loadObjectModel(model, load, object);
+  let model: unknown;
+  if (object.type === 'FUGR/FF' && functionGroupName) {
+    try {
+      model = await AdkFunctionModule.get(functionGroupName, object.name, ctx);
+    } catch {
+      throw new ObjectSourceHistoryError(
+        'OBJECT_METADATA_LOAD_FAILED',
+        'SAP ADT rejected repository object metadata retrieval.',
+        object,
+      );
+    }
+  } else {
+    model = createAdkFactory(ctx).get(object.name, object.type);
+    const load = ensureObjectLoadable(asRecord(model), object);
+    await loadObjectModel(model, load, object);
+  }
 
   const { metadata, objectUri } = ensureObjectMetadata(model, object);
 
@@ -645,6 +660,7 @@ interface RepositoryObjectReference {
   type: string;
   name: string;
   isDeleted: boolean;
+  functionGroupName?: string;
 }
 
 function repositoryNameFromUri(
@@ -721,7 +737,13 @@ async function resolveFuncGroupBySearch(
       .map((item) => repositoryNameFromUri(nonEmptyString(item['uri']), 'FUGR'))
       .find((name): name is string => Boolean(name));
     return ownerName
-      ? { pgmid: 'R3TR', type: 'FUGR', name: ownerName, isDeleted: false }
+      ? {
+          pgmid: 'R3TR',
+          type: 'FUGR/FF',
+          name: reference.name.trim().toUpperCase(),
+          functionGroupName: ownerName,
+          isDeleted: false,
+        }
       : undefined;
   } catch {
     return undefined;
@@ -895,6 +917,7 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
       sourceHistoryDiscoveryType(repository),
       ctx,
       false,
+      repository.functionGroupName,
     );
   } catch (error) {
     if (!(error instanceof ObjectSourceHistoryError)) throw error;

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -430,7 +430,24 @@ async function discoverObjectSourceHistory(
 
   const { metadata, objectUri } = ensureObjectMetadata(model, object);
 
-  const packageName = packageNameFrom(metadata);
+  let packageName = packageNameFrom(metadata);
+  // Function-module metadata has no top-level packageRef; inherit the
+  // owning function group's package so the manifest entry stays scoped.
+  if (!packageName && functionGroupName) {
+    const fugrModel = createAdkFactory(ctx).get(functionGroupName, 'FUGR');
+    const fugrLoad = ensureObjectLoadable(asRecord(fugrModel), {
+      name: functionGroupName,
+      type: 'FUGR',
+    });
+    await loadObjectModel(fugrModel, fugrLoad, {
+      name: functionGroupName,
+      type: 'FUGR',
+    });
+    const fugrMetadata = loadedMetadata(fugrModel);
+    if (fugrMetadata) {
+      packageName = packageNameFrom(fugrMetadata);
+    }
+  }
   const normalizedObject = {
     ...object,
     ...(packageName ? { packageName } : {}),
@@ -742,7 +759,7 @@ async function resolveFuncGroupBySearch(
           type: 'FUGR/FF',
           name: reference.name.trim().toUpperCase(),
           functionGroupName: ownerName,
-          isDeleted: false,
+          isDeleted: reference.isDeleted,
         }
       : undefined;
   } catch {
@@ -832,6 +849,8 @@ function manifestSelectorMatches(
   selector: TransportObjectSelector | undefined,
 ): boolean {
   if (!selector) return true;
+  const repositoryType = repository.type.trim().toUpperCase();
+  const repositoryMainType = repositoryType.split('/')[0] ?? '';
   return (
     selectorDimensionMatches(
       [original.objFunc.trim().toUpperCase()],
@@ -842,7 +861,13 @@ function manifestSelectorMatches(
       selector.pgmid,
     ) &&
     selectorDimensionMatches(
-      [original.type.trim().toUpperCase(), repository.type.toUpperCase()],
+      [
+        original.type.trim().toUpperCase(),
+        repositoryType,
+        ...(repositoryMainType && repositoryMainType !== repositoryType
+          ? [repositoryMainType]
+          : []),
+      ],
       selector.type,
     )
   );

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -967,8 +967,8 @@ describe('buildTransportSourceManifest', () => {
         }),
         repositoryObject: expect.objectContaining({
           pgmid: 'R3TR',
-          type: 'FUGR/FF',
-          name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+          type: 'FUGR',
+          name: 'ZFG_PY_LEAN',
         }),
       }),
     ]);

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -4,6 +4,7 @@ import type { AdkContext } from '../src/base/context';
 
 const resolveTransportObjectsMock = vi.hoisted(() => vi.fn());
 const createAdkFactoryMock = vi.hoisted(() => vi.fn());
+const functionModuleGetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/objects/cts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../src/objects/cts')>()),
@@ -13,6 +14,11 @@ vi.mock('../src/objects/cts', async (importOriginal) => ({
 vi.mock('../src/factory', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../src/factory')>()),
   createAdkFactory: createAdkFactoryMock,
+}));
+
+vi.mock('../src/objects/repository/fugr', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/objects/repository/fugr')>()),
+  AdkFunctionModule: { get: functionModuleGetMock },
 }));
 
 import {
@@ -56,6 +62,21 @@ interface FakeTransportObjectOptions {
 
 const factoryObjects = new Map<string, unknown>();
 const factoryGet = vi.fn();
+const functionModuleObjects = new Map<string, unknown>();
+
+function functionModuleObject(
+  groupName: string,
+  name: string,
+  metadata: Record<string, unknown> = rootSourceMetadata(),
+) {
+  const model = {
+    objectUri: `/sap/bc/adt/functions/groups/${groupName.toLowerCase()}/fmodules/${name.toLowerCase()}`,
+    dataSync: metadata,
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+  functionModuleObjects.set(`${groupName}/${name}`, model);
+  return model;
+}
 
 function transportObject({
   name,
@@ -564,6 +585,12 @@ describe('buildTransportSourceManifest', () => {
     createAdkFactoryMock.mockReturnValue({
       get: factoryGet,
     });
+    functionModuleObjects.clear();
+    functionModuleGetMock.mockReset();
+    functionModuleGetMock.mockImplementation(
+      async (groupName: string, name: string) =>
+        functionModuleObjects.get(`${groupName}/${name}`),
+    );
   });
 
   it('builds an exact metadata-only manifest with concrete task provenance', async () => {
@@ -893,8 +920,8 @@ describe('buildTransportSourceManifest', () => {
       wbtype: 'FUGR/FF',
       objectUri: '',
       factoryName: 'ZFG_PY_LEAN',
-      metadata: rootSourceMetadata(),
     });
+    functionModuleObject('ZFG_PY_LEAN', 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21');
     mockResolution([functionModule], ['S0DK955760'], ['S0DK955760']);
     const { ctx, quickSearch } = contextWithVersions(
       vi.fn().mockResolvedValue([version('00001', 0, ['S0DK955760'])]),
@@ -926,7 +953,11 @@ describe('buildTransportSourceManifest', () => {
       query: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
       maxResults: 10,
     });
-    expect(factoryGet).toHaveBeenCalledWith('ZFG_PY_LEAN', 'FUGR');
+    expect(functionModuleGetMock).toHaveBeenCalledWith(
+      'ZFG_PY_LEAN',
+      'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+      ctx,
+    );
     expect(manifest.entries).toEqual([
       expect.objectContaining({
         object: expect.objectContaining({
@@ -936,8 +967,8 @@ describe('buildTransportSourceManifest', () => {
         }),
         repositoryObject: expect.objectContaining({
           pgmid: 'R3TR',
-          type: 'FUGR',
-          name: 'ZFG_PY_LEAN',
+          type: 'FUGR/FF',
+          name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
         }),
       }),
     ]);

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -67,7 +67,11 @@ const functionModuleObjects = new Map<string, unknown>();
 function functionModuleObject(
   groupName: string,
   name: string,
-  metadata: Record<string, unknown> = rootSourceMetadata(),
+  metadata: Record<string, unknown> = Object.fromEntries(
+    Object.entries(rootSourceMetadata()).filter(
+      ([key]) => key !== 'packageRef',
+    ),
+  ),
 ) {
   const model = {
     objectUri: `/sap/bc/adt/functions/groups/${groupName.toLowerCase()}/fmodules/${name.toLowerCase()}`,
@@ -920,6 +924,7 @@ describe('buildTransportSourceManifest', () => {
       wbtype: 'FUGR/FF',
       objectUri: '',
       factoryName: 'ZFG_PY_LEAN',
+      metadata: rootSourceMetadata(),
     });
     functionModuleObject('ZFG_PY_LEAN', 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21');
     mockResolution([functionModule], ['S0DK955760'], ['S0DK955760']);
@@ -958,17 +963,20 @@ describe('buildTransportSourceManifest', () => {
       'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
       ctx,
     );
+    expect(factoryGet).toHaveBeenCalledWith('ZFG_PY_LEAN', 'FUGR');
     expect(manifest.entries).toEqual([
       expect.objectContaining({
         object: expect.objectContaining({
           pgmid: 'LIMU',
           type: 'FUNC',
           name: 'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+          packageName: 'ZPACKAGE',
         }),
         repositoryObject: expect.objectContaining({
           pgmid: 'R3TR',
           type: 'FUGR',
           name: 'ZFG_PY_LEAN',
+          packageName: 'ZPACKAGE',
         }),
       }),
     ]);


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes source history resolution for LIMU FUNC entries so immutable history comes from the function module itself rather than the parent function group.

- Loads module metadata via `AdkFunctionModule.get` for `FUGR/FF` objects and inherits the owning group's package when module metadata lacks one.
- Preserves deletion state and lets `FUGR/FF` match `FUGR` selector filters.
- Retains the parent function group for formatter metadata.

<sup>Written for commit 849c99f9b2332af473c67f77b10ae83f2ef169f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Gitar

- **Source History & Manifests:**
    - Use function-module source history for `FUGR/FF` objects via `AdkFunctionModule`
    - Preserve function-group materialization owner in transport source manifests

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery of function-module source history when a function group is specified.
  * Function-module search results now retain their identity and associated function-group information.
  * Repository manifest metadata more accurately reflects the owning function group.
  * Improved loading of function-module objects during source discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Use function-module history and preserve correct function-group provenance for LIMU FUNC entries

### What Changed
- LIMU FUNC entries now use the specific function module’s source history instead of the function-group root
- Function-group ownership remains attached to manifest and formatter metadata
- Function-module entries inherit the owning function group’s package when their own metadata lacks it
- Deleted LIMU FUNC entries retain their deleted status
- Function-group searches avoid same-named non-function objects, and type filters recognize FUGR/FF entries

### Impact
`✅ Accurate function-module version history`
`✅ Correct package and function-group provenance`
`✅ Reliable deleted-entry reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
