### PR TITLE
feat(flow): report partial transport import gaps

### DIFF
--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { realpathSync } from 'node:fs';
+import { lstatSync, readlinkSync, realpathSync } from 'node:fs';
 import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import type { AdtClient } from '@abapify/adt-client';
@@ -93,9 +93,10 @@ function partialReportPath(
   // Resolve symlinks in the parent directory to detect in-root symlinks
   // that point outside the checkout. The target file itself may not exist
   // yet, so we resolve its parent. If the parent doesn't exist either,
-  // walk up to the nearest existing ancestor, resolve that, and re-append
-  // the remaining path segments — this catches symlinks in existing
-  // ancestors that would be followed by mkdir/writeFile.
+  // walk up to the nearest existing ancestor, resolving that, and
+  // re-append the remaining path segments. At each step, check for
+  // dangling symlinks (existing lstat but realpath fails) that point
+  // outside the checkout — mkdir/writeFile would follow them.
   const parent = dirname(target);
   const base = basename(target);
   let realParent: string;
@@ -107,6 +108,31 @@ function partialReportPath(
     let current = parent;
     const segments: string[] = [];
     for (;;) {
+      // Check if current is a dangling symlink — it exists as a
+      // symlink but its target doesn't resolve. Reject if the link
+      // target escapes the checkout root.
+      try {
+        const stat = lstatSync(current);
+        if (stat.isSymbolicLink()) {
+          const linkTarget = resolve(dirname(current), readlinkSync(current));
+          const fromRootLink = relative(realRoot, linkTarget);
+          if (
+            isAbsolute(fromRootLink) ||
+            fromRootLink === '..' ||
+            fromRootLink.startsWith(
+              `..${process.platform === 'win32' ? '\\' : '/'}`,
+            )
+          ) {
+            throw new AdtFlowError(
+              'invalid_input',
+              '--partial-report must not escape the checkout root via symlinks.',
+            );
+          }
+        }
+      } catch (error) {
+        if (error instanceof AdtFlowError) throw error;
+        // lstat failed — path doesn't exist at all, continue walking up.
+      }
       try {
         realParent = resolve(realpathSync(current), ...segments.reverse());
         break;

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve } from 'node:path';
 import type { AdtClient } from '@abapify/adt-client';
@@ -61,6 +62,12 @@ function partialReportPath(value: unknown, root: string): string | undefined {
   }
   const target = resolve(root, value);
   const fromRoot = relative(root, target);
+  if (fromRoot === '') {
+    throw new AdtFlowError(
+      'invalid_input',
+      '--partial-report must not target the checkout root directory.',
+    );
+  }
   if (
     fromRoot === '..' ||
     fromRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
@@ -87,7 +94,7 @@ async function writePartialReport(
     2,
   )}\n`;
   await mkdir(dirname(output), { recursive: true });
-  const temporary = `${output}.${process.pid}.tmp`;
+  const temporary = `${output}.${randomUUID()}.tmp`;
   await writeFile(temporary, payload, 'utf8');
   await rename(temporary, output);
 }

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -1,3 +1,5 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
 import type { AdtClient } from '@abapify/adt-client';
 import type { FlowConfig } from '@abapify/adt-config';
 import {
@@ -191,5 +193,3 @@ export function createFlowCommand(
 
 export const flowCommand = createFlowCommand();
 export default flowCommand;
-import { mkdir, rename, writeFile } from 'node:fs/promises';
-import { dirname, relative, resolve } from 'node:path';

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -92,16 +92,36 @@ function partialReportPath(
   }
   // Resolve symlinks in the parent directory to detect in-root symlinks
   // that point outside the checkout. The target file itself may not exist
-  // yet, so we resolve its parent and re-append the basename.
+  // yet, so we resolve its parent. If the parent doesn't exist either,
+  // walk up to the nearest existing ancestor, resolve that, and re-append
+  // the remaining path segments — this catches symlinks in existing
+  // ancestors that would be followed by mkdir/writeFile.
   const parent = dirname(target);
+  const base = basename(target);
   let realParent: string;
   try {
     realParent = realpathSync(parent);
   } catch {
-    // Parent doesn't exist yet — no symlink can be there, so it's safe.
-    realParent = parent;
+    // Parent doesn't exist — walk up to the nearest existing ancestor
+    // and re-append the non-existent segments.
+    let current = parent;
+    const segments: string[] = [];
+    for (;;) {
+      try {
+        realParent = resolve(realpathSync(current), ...segments.reverse());
+        break;
+      } catch {
+        segments.push(basename(current));
+        const next = dirname(current);
+        if (next === current) {
+          realParent = parent;
+          break;
+        }
+        current = next;
+      }
+    }
   }
-  const realTarget = resolve(realParent, basename(target));
+  const realTarget = resolve(realParent, base);
   const fromRealRoot = relative(realRoot, realTarget);
   if (
     fromRealRoot === '' ||
@@ -144,7 +164,9 @@ async function writePartialReport(
     await writeFile(temporary, payload, 'utf8');
     await rename(temporary, output);
   } catch (error) {
-    await unlink(temporary).catch(() => {});
+    await unlink(temporary).catch(() => {
+      // Ignore cleanup failures — the original error is more important.
+    });
     throw error;
   }
 }

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -108,25 +108,49 @@ function partialReportPath(
     let current = parent;
     const segments: string[] = [];
     for (;;) {
-      // Check if current is a dangling symlink — it exists as a
-      // symlink but its target doesn't resolve. Reject if the link
-      // target escapes the checkout root.
+      // Check if current is a symlink (including dangling ones). Follow
+      // the entire symlink chain, resolving each hop, and reject if any
+      // hop escapes the checkout root.
       try {
         const stat = lstatSync(current);
         if (stat.isSymbolicLink()) {
-          const linkTarget = resolve(dirname(current), readlinkSync(current));
-          const fromRootLink = relative(realRoot, linkTarget);
-          if (
-            isAbsolute(fromRootLink) ||
-            fromRootLink === '..' ||
-            fromRootLink.startsWith(
-              `..${process.platform === 'win32' ? '\\' : '/'}`,
-            )
-          ) {
-            throw new AdtFlowError(
-              'invalid_input',
-              '--partial-report must not escape the checkout root via symlinks.',
+          let linkCurrent = current;
+          const seen = new Set<string>();
+          for (;;) {
+            if (seen.has(linkCurrent)) {
+              // Symlink loop — reject to avoid infinite recursion.
+              throw new AdtFlowError(
+                'invalid_input',
+                '--partial-report path contains a symlink loop.',
+              );
+            }
+            seen.add(linkCurrent);
+            let stat2: ReturnType<typeof lstatSync>;
+            try {
+              stat2 = lstatSync(linkCurrent);
+            } catch {
+              // Dangling symlink target — check where it points.
+              break;
+            }
+            if (!stat2?.isSymbolicLink()) break;
+            const linkTarget = resolve(
+              dirname(linkCurrent),
+              readlinkSync(linkCurrent),
             );
+            const fromRootLink = relative(realRoot, linkTarget);
+            if (
+              isAbsolute(fromRootLink) ||
+              fromRootLink === '..' ||
+              fromRootLink.startsWith(
+                `..${process.platform === 'win32' ? '\\' : '/'}`,
+              )
+            ) {
+              throw new AdtFlowError(
+                'invalid_input',
+                '--partial-report must not escape the checkout root via symlinks.',
+              );
+            }
+            linkCurrent = linkTarget;
           }
         }
       } catch (error) {

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -191,6 +191,7 @@ function partialReportPath(
 
 async function writePartialReport(
   output: string,
+  realRoot: string,
   result: Awaited<ReturnType<AdtFlowService['checkout']>>,
 ): Promise<void> {
   const skipped = [...result.skipped].sort((a, b) => {
@@ -210,6 +211,11 @@ async function writePartialReport(
     null,
     2,
   )}\n`;
+  // Re-validate the output path right before writing to mitigate
+  // TOCTOU: a parent directory could be replaced with a symlink
+  // between partialReportPath validation and the actual write.
+  assertNoSymlinkEscape(output, realRoot);
+  assertNoSymlinkEscape(dirname(output), realRoot);
   await mkdir(dirname(output), { recursive: true });
   const temporary = `${output}.${randomUUID()}.tmp`;
   try {
@@ -295,7 +301,7 @@ function checkoutTrCommand(
         partial: args['partial'] === true,
         config,
       });
-      if (report) await writePartialReport(report, result);
+      if (report) await writePartialReport(report, realRoot, result);
       ctx.logger.info(
         `Checked out ${result.mode} for ${result.requestedTransports.join(', ')}: ` +
           `${result.changed.length} changed, ${result.moved.length} moved, ` +

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -54,6 +54,45 @@ function flowConfig(ctx: CliContext): FlowConfig {
   }
 }
 
+function escapeRoot(realRoot: string, path: string): boolean {
+  const fromRoot = relative(realRoot, path);
+  return (
+    isAbsolute(fromRoot) ||
+    fromRoot === '..' ||
+    fromRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
+  );
+}
+
+function assertNoSymlinkEscape(path: string, realRoot: string): void {
+  let linkCurrent = path;
+  const seen = new Set<string>();
+  for (;;) {
+    if (seen.has(linkCurrent)) {
+      throw new AdtFlowError(
+        'invalid_input',
+        '--partial-report path contains a symlink loop.',
+      );
+    }
+    seen.add(linkCurrent);
+    let stat: ReturnType<typeof lstatSync>;
+    try {
+      stat = lstatSync(linkCurrent);
+    } catch {
+      // Dangling symlink target — already checked the hop, stop.
+      return;
+    }
+    if (!stat?.isSymbolicLink()) return;
+    const linkTarget = resolve(dirname(linkCurrent), readlinkSync(linkCurrent));
+    if (escapeRoot(realRoot, linkTarget)) {
+      throw new AdtFlowError(
+        'invalid_input',
+        '--partial-report must not escape the checkout root via symlinks.',
+      );
+    }
+    linkCurrent = linkTarget;
+  }
+}
+
 function partialReportPath(
   value: unknown,
   root: string,
@@ -80,11 +119,7 @@ function partialReportPath(
       '--partial-report must not target the checkout root directory.',
     );
   }
-  if (
-    isAbsolute(fromRoot) ||
-    fromRoot === '..' ||
-    fromRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
-  ) {
+  if (escapeRoot(root, target)) {
     throw new AdtFlowError(
       'invalid_input',
       '--partial-report must remain inside the checkout root.',
@@ -108,51 +143,10 @@ function partialReportPath(
     let current = parent;
     const segments: string[] = [];
     for (;;) {
-      // Check if current is a symlink (including dangling ones). Follow
-      // the entire symlink chain, resolving each hop, and reject if any
-      // hop escapes the checkout root.
+      // Check if current is a symlink (including dangling ones) whose
+      // chain escapes the checkout root.
       try {
-        const stat = lstatSync(current);
-        if (stat.isSymbolicLink()) {
-          let linkCurrent = current;
-          const seen = new Set<string>();
-          for (;;) {
-            if (seen.has(linkCurrent)) {
-              // Symlink loop — reject to avoid infinite recursion.
-              throw new AdtFlowError(
-                'invalid_input',
-                '--partial-report path contains a symlink loop.',
-              );
-            }
-            seen.add(linkCurrent);
-            let stat2: ReturnType<typeof lstatSync>;
-            try {
-              stat2 = lstatSync(linkCurrent);
-            } catch {
-              // Dangling symlink target — check where it points.
-              break;
-            }
-            if (!stat2?.isSymbolicLink()) break;
-            const linkTarget = resolve(
-              dirname(linkCurrent),
-              readlinkSync(linkCurrent),
-            );
-            const fromRootLink = relative(realRoot, linkTarget);
-            if (
-              isAbsolute(fromRootLink) ||
-              fromRootLink === '..' ||
-              fromRootLink.startsWith(
-                `..${process.platform === 'win32' ? '\\' : '/'}`,
-              )
-            ) {
-              throw new AdtFlowError(
-                'invalid_input',
-                '--partial-report must not escape the checkout root via symlinks.',
-              );
-            }
-            linkCurrent = linkTarget;
-          }
-        }
+        assertNoSymlinkEscape(current, realRoot);
       } catch (error) {
         if (error instanceof AdtFlowError) throw error;
         // lstat failed — path doesn't exist at all, continue walking up.
@@ -172,13 +166,7 @@ function partialReportPath(
     }
   }
   const realTarget = resolve(realParent, base);
-  const fromRealRoot = relative(realRoot, realTarget);
-  if (
-    fromRealRoot === '' ||
-    isAbsolute(fromRealRoot) ||
-    fromRealRoot === '..' ||
-    fromRealRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
-  ) {
+  if (escapeRoot(realRoot, realTarget)) {
     throw new AdtFlowError(
       'invalid_input',
       '--partial-report must not escape the checkout root via symlinks.',

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, rename, writeFile } from 'node:fs/promises';
-import { dirname, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import type { AdtClient } from '@abapify/adt-client';
 import type { FlowConfig } from '@abapify/adt-config';
 import {
@@ -10,6 +10,7 @@ import {
   type FormatPlugin,
 } from '@abapify/adt-plugin';
 import { createAdtFlowDependencies } from '../adt-client-adapter';
+import { compareStrings } from '../deterministic';
 import { createAdtFlowService, type AdtFlowService } from '../service';
 import { flowConfigSchema } from '../schemas';
 import { AdtFlowError } from '../types';
@@ -60,6 +61,12 @@ function partialReportPath(value: unknown, root: string): string | undefined {
       '--partial-report requires a non-empty repository-relative file path.',
     );
   }
+  if (isAbsolute(value)) {
+    throw new AdtFlowError(
+      'invalid_input',
+      '--partial-report must be a repository-relative path, not absolute.',
+    );
+  }
   const target = resolve(root, value);
   const fromRoot = relative(root, target);
   if (fromRoot === '') {
@@ -69,6 +76,7 @@ function partialReportPath(value: unknown, root: string): string | undefined {
     );
   }
   if (
+    isAbsolute(fromRoot) ||
     fromRoot === '..' ||
     fromRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
   ) {
@@ -84,11 +92,18 @@ async function writePartialReport(
   output: string,
   result: Awaited<ReturnType<AdtFlowService['checkout']>>,
 ): Promise<void> {
+  const skipped = [...result.skipped].sort((a, b) => {
+    return (
+      compareStrings(a.object, b.object) ||
+      compareStrings(a.component, b.component) ||
+      compareStrings(a.diagnostic, b.diagnostic)
+    );
+  });
   const payload = `${JSON.stringify(
     {
       schemaVersion: 1,
       requestedTransports: result.requestedTransports,
-      skipped: result.skipped,
+      skipped,
     },
     null,
     2,

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -49,6 +49,47 @@ function flowConfig(ctx: CliContext): FlowConfig {
   }
 }
 
+function partialReportPath(value: unknown, root: string): string | undefined {
+  if (value === undefined || value === false) return undefined;
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new AdtFlowError(
+      'invalid_input',
+      '--partial-report requires a non-empty repository-relative file path.',
+    );
+  }
+  const target = resolve(root, value);
+  const fromRoot = relative(root, target);
+  if (
+    fromRoot === '..' ||
+    fromRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
+  ) {
+    throw new AdtFlowError(
+      'invalid_input',
+      '--partial-report must remain inside the checkout root.',
+    );
+  }
+  return target;
+}
+
+async function writePartialReport(
+  output: string,
+  result: Awaited<ReturnType<AdtFlowService['checkout']>>,
+): Promise<void> {
+  const payload = `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      requestedTransports: result.requestedTransports,
+      skipped: result.skipped,
+    },
+    null,
+    2,
+  )}\n`;
+  await mkdir(dirname(output), { recursive: true });
+  const temporary = `${output}.${process.pid}.tmp`;
+  await writeFile(temporary, payload, 'utf8');
+  await rename(temporary, output);
+}
+
 function checkoutTrCommand(
   dependencies: FlowCommandDependencies,
 ): CliCommandPlugin {
@@ -65,6 +106,16 @@ function checkoutTrCommand(
       {
         flags: '--base',
         description: 'Checkout the version immediately before the scope',
+      },
+      {
+        flags: '--partial',
+        description:
+          'Materialize only objects with exact source-history boundaries',
+      },
+      {
+        flags: '--partial-report <file>',
+        description:
+          'Write skipped-object JSON after a successful partial checkout',
       },
     ],
     async execute(args, ctx) {
@@ -83,12 +134,21 @@ function checkoutTrCommand(
         );
       }
       const client = (await ctx.getAdtClient()) as AdtClient;
+      const report = partialReportPath(args['partial-report'], ctx.cwd);
+      if (report && args['partial'] !== true) {
+        throw new AdtFlowError(
+          'invalid_input',
+          '--partial-report requires the explicit --partial opt-in.',
+        );
+      }
       const result = await dependencies.createService(client, format).checkout({
         root: ctx.cwd,
         transports: transports(args['transport']),
         mode: args['base'] === true ? 'base' : 'head',
+        partial: args['partial'] === true,
         config,
       });
+      if (report) await writePartialReport(report, result);
       ctx.logger.info(
         `Checked out ${result.mode} for ${result.requestedTransports.join(', ')}: ` +
           `${result.changed.length} changed, ${result.moved.length} moved, ` +
@@ -96,7 +156,7 @@ function checkoutTrCommand(
       );
       for (const skipped of result.skipped) {
         ctx.logger.warn(
-          `Skipped unsupported object ${skipped.object} (${skipped.component}; ${skipped.diagnostic}).`,
+          `Skipped object ${skipped.object} (${skipped.component}; ${skipped.diagnostic}).`,
         );
       }
       ctx.logger.info(
@@ -126,3 +186,5 @@ export function createFlowCommand(
 
 export const flowCommand = createFlowCommand();
 export default flowCommand;
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, rename, writeFile } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import type { AdtClient } from '@abapify/adt-client';
 import type { FlowConfig } from '@abapify/adt-config';
 import {
@@ -53,7 +54,11 @@ function flowConfig(ctx: CliContext): FlowConfig {
   }
 }
 
-function partialReportPath(value: unknown, root: string): string | undefined {
+function partialReportPath(
+  value: unknown,
+  root: string,
+  realRoot: string,
+): string | undefined {
   if (value === undefined || value === false) return undefined;
   if (typeof value !== 'string' || !value.trim()) {
     throw new AdtFlowError(
@@ -85,6 +90,30 @@ function partialReportPath(value: unknown, root: string): string | undefined {
       '--partial-report must remain inside the checkout root.',
     );
   }
+  // Resolve symlinks in the parent directory to detect in-root symlinks
+  // that point outside the checkout. The target file itself may not exist
+  // yet, so we resolve its parent and re-append the basename.
+  const parent = dirname(target);
+  let realParent: string;
+  try {
+    realParent = realpathSync(parent);
+  } catch {
+    // Parent doesn't exist yet — no symlink can be there, so it's safe.
+    realParent = parent;
+  }
+  const realTarget = resolve(realParent, basename(target));
+  const fromRealRoot = relative(realRoot, realTarget);
+  if (
+    fromRealRoot === '' ||
+    isAbsolute(fromRealRoot) ||
+    fromRealRoot === '..' ||
+    fromRealRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
+  ) {
+    throw new AdtFlowError(
+      'invalid_input',
+      '--partial-report must not escape the checkout root via symlinks.',
+    );
+  }
   return target;
 }
 
@@ -96,7 +125,8 @@ async function writePartialReport(
     return (
       compareStrings(a.object, b.object) ||
       compareStrings(a.component, b.component) ||
-      compareStrings(a.diagnostic, b.diagnostic)
+      compareStrings(a.diagnostic, b.diagnostic) ||
+      compareStrings(a.sourceTransport ?? '', b.sourceTransport ?? '')
     );
   });
   const payload = `${JSON.stringify(
@@ -110,8 +140,13 @@ async function writePartialReport(
   )}\n`;
   await mkdir(dirname(output), { recursive: true });
   const temporary = `${output}.${randomUUID()}.tmp`;
-  await writeFile(temporary, payload, 'utf8');
-  await rename(temporary, output);
+  try {
+    await writeFile(temporary, payload, 'utf8');
+    await rename(temporary, output);
+  } catch (error) {
+    await unlink(temporary).catch(() => {});
+    throw error;
+  }
 }
 
 function checkoutTrCommand(
@@ -158,11 +193,20 @@ function checkoutTrCommand(
         );
       }
       const client = (await ctx.getAdtClient()) as AdtClient;
+      // Resolve the real checkout root once to detect symlink escapes
+      // in --partial-report paths. Fall back to cwd if realpath fails.
+      let realRoot: string;
+      try {
+        realRoot = realpathSync(ctx.cwd);
+      } catch {
+        realRoot = ctx.cwd;
+      }
       // Commander normalizes --partial-report to partialReport at runtime;
       // retain the dashed spelling for direct plugin callers and tests.
       const report = partialReportPath(
         args.partialReport ?? args['partial-report'],
         ctx.cwd,
+        realRoot,
       );
       if (report && args['partial'] !== true) {
         throw new AdtFlowError(

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -74,25 +74,14 @@ function assertNoSymlinkEscape(path: string, realRoot: string): void {
       );
     }
     seen.add(linkCurrent);
-    let stat: ReturnType<typeof lstatSync>;
-    try {
-      stat = lstatSync(linkCurrent);
-    } catch {
-      // Dangling or non-existent target. The direct escape check for
-      // this hop was already done. But the resolved path may contain
-      // intermediate symlink components in its parent chain — walk
-      // up the parent to check those.
-      const parent = dirname(linkCurrent);
-      if (parent !== linkCurrent) {
-        try {
-          assertNoSymlinkEscape(parent, realRoot);
-        } catch (error) {
-          if (error instanceof AdtFlowError) throw error;
-        }
-      }
+    const stat = tryLstat(linkCurrent);
+    if (stat === undefined) {
+      // Dangling or non-existent target — check parent chain for
+      // intermediate symlink components that escape the checkout.
+      assertParentChainSafe(linkCurrent, realRoot);
       return;
     }
-    if (!stat?.isSymbolicLink()) return;
+    if (!stat.isSymbolicLink()) return;
     const linkTarget = resolve(dirname(linkCurrent), readlinkSync(linkCurrent));
     if (escapeRoot(realRoot, linkTarget)) {
       throw new AdtFlowError(
@@ -101,6 +90,24 @@ function assertNoSymlinkEscape(path: string, realRoot: string): void {
       );
     }
     linkCurrent = linkTarget;
+  }
+}
+
+function tryLstat(path: string): ReturnType<typeof lstatSync> | undefined {
+  try {
+    return lstatSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function assertParentChainSafe(path: string, realRoot: string): void {
+  const parent = dirname(path);
+  if (parent === path) return;
+  try {
+    assertNoSymlinkEscape(parent, realRoot);
+  } catch (error) {
+    if (error instanceof AdtFlowError) throw error;
   }
 }
 

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -134,7 +134,12 @@ function checkoutTrCommand(
         );
       }
       const client = (await ctx.getAdtClient()) as AdtClient;
-      const report = partialReportPath(args['partial-report'], ctx.cwd);
+      // Commander normalizes --partial-report to partialReport at runtime;
+      // retain the dashed spelling for direct plugin callers and tests.
+      const report = partialReportPath(
+        args.partialReport ?? args['partial-report'],
+        ctx.cwd,
+      );
       if (report && args['partial'] !== true) {
         throw new AdtFlowError(
           'invalid_input',

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -78,7 +78,18 @@ function assertNoSymlinkEscape(path: string, realRoot: string): void {
     try {
       stat = lstatSync(linkCurrent);
     } catch {
-      // Dangling symlink target — already checked the hop, stop.
+      // Dangling or non-existent target. The direct escape check for
+      // this hop was already done. But the resolved path may contain
+      // intermediate symlink components in its parent chain — walk
+      // up the parent to check those.
+      const parent = dirname(linkCurrent);
+      if (parent !== linkCurrent) {
+        try {
+          assertNoSymlinkEscape(parent, realRoot);
+        } catch (error) {
+          if (error instanceof AdtFlowError) throw error;
+        }
+      }
       return;
     }
     if (!stat?.isSymbolicLink()) return;
@@ -172,6 +183,9 @@ function partialReportPath(
       '--partial-report must not escape the checkout root via symlinks.',
     );
   }
+  // Validate the target file itself — if it already exists as a symlink,
+  // the report write would replace it or follow it outside the checkout.
+  assertNoSymlinkEscape(target, realRoot);
   return target;
 }
 

--- a/packages/adt-flow/src/index.ts
+++ b/packages/adt-flow/src/index.ts
@@ -30,4 +30,5 @@ export {
   type FlowErrorCode,
   type FlowObjectIdentity,
   type FlowObjectModel,
+  type FlowSkippedObject,
 } from './types';

--- a/packages/adt-flow/src/schemas.ts
+++ b/packages/adt-flow/src/schemas.ts
@@ -152,6 +152,8 @@ export const transportDescriptorSchema = z.object({
   objects: z.array(z.string().min(1)),
   configDigest: z.string().regex(/^[a-f0-9]{64}$/),
   formatDigest: z.string().regex(/^[a-f0-9]{64}$/),
+  /** Present only when at least one object was deliberately omitted. */
+  incomplete: z.boolean().optional(),
 });
 
 export type ObjectDescriptor = z.infer<typeof objectDescriptorSchema>;

--- a/packages/adt-flow/src/schemas.ts
+++ b/packages/adt-flow/src/schemas.ts
@@ -153,7 +153,7 @@ export const transportDescriptorSchema = z.object({
   configDigest: z.string().regex(/^[a-f0-9]{64}$/),
   formatDigest: z.string().regex(/^[a-f0-9]{64}$/),
   /** Present only when at least one object was deliberately omitted. */
-  incomplete: z.boolean().optional(),
+  incomplete: z.literal(true).optional(),
 });
 
 export type ObjectDescriptor = z.infer<typeof objectDescriptorSchema>;

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -1009,15 +1009,77 @@ function inexactEntries(
   return inexact;
 }
 
-function skippedInexactEntries(
+async function skippedInexactEntries(
   entries: readonly TransportSourceManifestEntry[],
-): FlowCheckoutResult['skipped'] {
-  return entries.map((entry) => ({
-    object: `${entry.object.type}/${entry.object.name}`,
-    component: entry.component.id,
-    diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
-    sourceTransport: entry.sourceTransport,
-  }));
+  ctx: CheckoutContext,
+  limiter: Limiter,
+  hasApplicationComponentFilter: boolean,
+): Promise<FlowCheckoutResult['skipped']> {
+  if (!hasApplicationComponentFilter) {
+    return entries.map((entry) => ({
+      object: `${entry.object.type}/${entry.object.name}`,
+      component: entry.component.id,
+      diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
+      sourceTransport: entry.sourceTransport,
+    }));
+  }
+
+  const byIdentity = new Map<
+    string,
+    { identity: FlowObjectIdentity; entries: TransportSourceManifestEntry[] }
+  >();
+  for (const entry of entries) {
+    const identity = objectIdentity(materializedObject(entry));
+    const existing = byIdentity.get(identity.canonical);
+    if (existing) {
+      existing.entries.push(entry);
+    } else {
+      byIdentity.set(identity.canonical, { identity, entries: [entry] });
+    }
+  }
+
+  const skipped: FlowCheckoutResult['skipped'] = [];
+  const pushSkipped = (identityEntries: TransportSourceManifestEntry[]) => {
+    for (const entry of identityEntries) {
+      skipped.push({
+        object: `${entry.object.type}/${entry.object.name}`,
+        component: entry.component.id,
+        diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
+        sourceTransport: entry.sourceTransport,
+      });
+    }
+  };
+
+  await Promise.all(
+    [...byIdentity.values()].map(
+      async ({ identity, entries: identityEntries }) => {
+        if (
+          identityEntries.some(
+            (entry) => entry.diagnostic?.code === 'OBJECT_METADATA_LOAD_FAILED',
+          )
+        ) {
+          pushSkipped(identityEntries);
+          return;
+        }
+
+        try {
+          const model = await limiter.run(() =>
+            ctx.dependencies.loadObject(identity),
+          );
+          ctx.calls.metadata += model.metadataCalls ?? 1;
+          if (isApplicationComponentExcluded(ctx.config, model)) return;
+          pushSkipped(identityEntries);
+        } catch (error) {
+          if (error instanceof AdtFlowError) {
+            pushSkipped(identityEntries);
+            return;
+          }
+          throw error;
+        }
+      },
+    ),
+  );
+  return skipped;
 }
 
 async function unsupportedEntries(
@@ -1116,7 +1178,14 @@ async function buildManifestAndGroups(
     hasApplicationComponentFilter,
   );
   const inexact = inexactEntries(scopedEntries, ctx.partial);
-  skipped.push(...skippedInexactEntries(inexact));
+  skipped.push(
+    ...(await skippedInexactEntries(
+      inexact,
+      ctx,
+      metadataLimiter,
+      hasApplicationComponentFilter,
+    )),
+  );
   const entries = scopedEntries.filter(
     (entry) => !isUnsupportedEntry(entry) && !inexact.includes(entry),
   );

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -1422,7 +1422,7 @@ async function checkoutFlow(
     ctx,
     manifestContext.manifest,
     processed,
-    manifestContext.skipped.length > 0,
+    manifestContext.skipped.length > 0 && ctx.partial,
   );
   processed.desired.sort((left, right) =>
     compareStrings(left.path, right.path),

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -334,6 +334,7 @@ async function exactHeadFastPath(
     descriptors.some(
       (descriptor, index) =>
         !descriptor ||
+        descriptor.incomplete === true ||
         descriptor.configDigest !== configDigest ||
         descriptor.formatDigest !== formatDigest ||
         descriptor.inventory === undefined ||
@@ -880,6 +881,7 @@ export interface AdtFlowService {
 interface CheckoutContext {
   root: string;
   mode: 'base' | 'head';
+  partial: boolean;
   requested: string[];
   config: FlowConfig;
   configDigest: string;
@@ -913,6 +915,7 @@ function createCheckoutContext(
   return {
     root: input.root,
     mode: input.mode ?? 'head',
+    partial: input.partial === true,
     requested: normalizeTransports(input.transports),
     config,
     configDigest: digest(config),
@@ -989,6 +992,32 @@ function prepareGroups(
     for (const entry of group.entries) selectedVersion(entry, mode);
   }
   return groups;
+}
+
+function inexactEntries(
+  entries: readonly TransportSourceManifestEntry[],
+  partial: boolean,
+): TransportSourceManifestEntry[] {
+  const inexact = entries.filter(
+    (entry) => !entry.exact && !isUnsupportedEntry(entry),
+  );
+  if (inexact.length > 0 && !partial) {
+    // Preserve the original all-or-nothing safety contract for every caller
+    // which has not explicitly elected to publish an incomplete boundary.
+    selectedVersion(inexact[0]!, 'head');
+  }
+  return inexact;
+}
+
+function skippedInexactEntries(
+  entries: readonly TransportSourceManifestEntry[],
+): FlowCheckoutResult['skipped'] {
+  return entries.map((entry) => ({
+    object: `${entry.object.type}/${entry.object.name}`,
+    component: entry.component.id,
+    diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
+    sourceTransport: entry.sourceTransport,
+  }));
 }
 
 async function unsupportedEntries(
@@ -1086,7 +1115,11 @@ async function buildManifestAndGroups(
     metadataLimiter,
     hasApplicationComponentFilter,
   );
-  const entries = scopedEntries.filter((entry) => !isUnsupportedEntry(entry));
+  const inexact = inexactEntries(scopedEntries, ctx.partial);
+  skipped.push(...skippedInexactEntries(inexact));
+  const entries = scopedEntries.filter(
+    (entry) => !isUnsupportedEntry(entry) && !inexact.includes(entry),
+  );
   const sourceLimiter = new Limiter(
     ctx.config.concurrency?.sources ?? DEFAULT_SOURCE_CONCURRENCY,
   );
@@ -1243,6 +1276,7 @@ async function addTransportDescriptors(
   ctx: CheckoutContext,
   manifest: TransportSourceManifest,
   accum: CheckoutAccumulator,
+  incomplete: boolean,
 ): Promise<void> {
   const { descriptorPaths, desired, ownedPaths, ownedOwners } = accum;
   const relevantObjectDescriptors = [...new Set(descriptorPaths)].sort(
@@ -1286,6 +1320,7 @@ async function addTransportDescriptors(
         objects: relevantObjectDescriptors,
         configDigest: ctx.configDigest,
         formatDigest: ctx.formatDigest,
+        ...(incomplete ? { incomplete: true } : {}),
       };
       desired.push({
         path,
@@ -1350,7 +1385,12 @@ async function checkoutFlow(
     manifestContext,
     pendingOwnership,
   );
-  await addTransportDescriptors(ctx, manifestContext.manifest, processed);
+  await addTransportDescriptors(
+    ctx,
+    manifestContext.manifest,
+    processed,
+    manifestContext.skipped.length > 0,
+  );
   processed.desired.sort((left, right) =>
     compareStrings(left.path, right.path),
   );

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -1104,6 +1104,9 @@ async function unsupportedEntries(
     object: `${entry.object.type}/${entry.object.name}`,
     component: entry.component.id,
     diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
+    ...(entry.sourceTransport
+      ? { sourceTransport: entry.sourceTransport }
+      : {}),
   });
   if (!hasApplicationComponentFilter) {
     return unsupported.map(toSkipped);

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -37,6 +37,7 @@ import {
   type FlowCheckoutResult,
   type FlowObjectIdentity,
   type FlowObjectModel,
+  type FlowSkippedObject,
 } from './types';
 
 const TRANSPORT = /^[A-Z0-9]{10}$/;
@@ -1009,21 +1010,12 @@ function inexactEntries(
   return inexact;
 }
 
-async function skippedInexactEntries(
+async function filterSkippedByApplicationComponent(
   entries: readonly TransportSourceManifestEntry[],
   ctx: CheckoutContext,
   limiter: Limiter,
-  hasApplicationComponentFilter: boolean,
+  toSkipped: (entry: TransportSourceManifestEntry) => FlowSkippedObject,
 ): Promise<FlowCheckoutResult['skipped']> {
-  if (!hasApplicationComponentFilter) {
-    return entries.map((entry) => ({
-      object: `${entry.object.type}/${entry.object.name}`,
-      component: entry.component.id,
-      diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
-      sourceTransport: entry.sourceTransport,
-    }));
-  }
-
   const byIdentity = new Map<
     string,
     { identity: FlowObjectIdentity; entries: TransportSourceManifestEntry[] }
@@ -1041,12 +1033,7 @@ async function skippedInexactEntries(
   const skipped: FlowCheckoutResult['skipped'] = [];
   const pushSkipped = (identityEntries: TransportSourceManifestEntry[]) => {
     for (const entry of identityEntries) {
-      skipped.push({
-        object: `${entry.object.type}/${entry.object.name}`,
-        component: entry.component.id,
-        diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
-        sourceTransport: entry.sourceTransport,
-      });
+      skipped.push(toSkipped(entry));
     }
   };
 
@@ -1082,6 +1069,28 @@ async function skippedInexactEntries(
   return skipped;
 }
 
+async function skippedInexactEntries(
+  entries: readonly TransportSourceManifestEntry[],
+  ctx: CheckoutContext,
+  limiter: Limiter,
+  hasApplicationComponentFilter: boolean,
+): Promise<FlowCheckoutResult['skipped']> {
+  const toSkipped = (
+    entry: TransportSourceManifestEntry,
+  ): FlowSkippedObject => ({
+    object: `${entry.object.type}/${entry.object.name}`,
+    component: entry.component.id,
+    diagnostic: entry.diagnostic?.code ?? 'MANIFEST_INEXACT',
+    ...(entry.sourceTransport
+      ? { sourceTransport: entry.sourceTransport }
+      : {}),
+  });
+  if (!hasApplicationComponentFilter) {
+    return entries.map(toSkipped);
+  }
+  return filterSkippedByApplicationComponent(entries, ctx, limiter, toSkipped);
+}
+
 async function unsupportedEntries(
   entries: readonly TransportSourceManifestEntry[],
   ctx: CheckoutContext,
@@ -1089,70 +1098,22 @@ async function unsupportedEntries(
   hasApplicationComponentFilter: boolean,
 ): Promise<FlowCheckoutResult['skipped']> {
   const unsupported = entries.filter(isUnsupportedEntry);
-
+  const toSkipped = (
+    entry: TransportSourceManifestEntry,
+  ): FlowSkippedObject => ({
+    object: `${entry.object.type}/${entry.object.name}`,
+    component: entry.component.id,
+    diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
+  });
   if (!hasApplicationComponentFilter) {
-    return unsupported.map((entry) => ({
-      object: `${entry.object.type}/${entry.object.name}`,
-      component: entry.component.id,
-      diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
-    }));
+    return unsupported.map(toSkipped);
   }
-
-  const byIdentity = new Map<
-    string,
-    { identity: FlowObjectIdentity; entries: TransportSourceManifestEntry[] }
-  >();
-  for (const entry of unsupported) {
-    const identity = objectIdentity(materializedObject(entry));
-    const existing = byIdentity.get(identity.canonical);
-    if (existing) {
-      existing.entries.push(entry);
-    } else {
-      byIdentity.set(identity.canonical, { identity, entries: [entry] });
-    }
-  }
-
-  const skipped: FlowCheckoutResult['skipped'] = [];
-  const pushSkipped = (identityEntries: TransportSourceManifestEntry[]) => {
-    for (const entry of identityEntries) {
-      skipped.push({
-        object: `${entry.object.type}/${entry.object.name}`,
-        component: entry.component.id,
-        diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
-      });
-    }
-  };
-
-  await Promise.all(
-    [...byIdentity.values()].map(
-      async ({ identity, entries: identityEntries }) => {
-        if (
-          identityEntries.some(
-            (entry) => entry.diagnostic?.code === 'OBJECT_METADATA_LOAD_FAILED',
-          )
-        ) {
-          pushSkipped(identityEntries);
-          return;
-        }
-
-        try {
-          const model = await limiter.run(() =>
-            ctx.dependencies.loadObject(identity),
-          );
-          ctx.calls.metadata += model.metadataCalls ?? 1;
-          if (isApplicationComponentExcluded(ctx.config, model)) return;
-          pushSkipped(identityEntries);
-        } catch (error) {
-          if (error instanceof AdtFlowError) {
-            pushSkipped(identityEntries);
-            return;
-          }
-          throw error;
-        }
-      },
-    ),
+  return filterSkippedByApplicationComponent(
+    unsupported,
+    ctx,
+    limiter,
+    toSkipped,
   );
-  return skipped;
 }
 
 async function buildManifestAndGroups(

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -935,6 +935,10 @@ async function tryExactHeadFastPath(
   ctx: CheckoutContext,
 ): Promise<FlowCheckoutResult | undefined> {
   if (ctx.mode !== 'head') return undefined;
+  // Partial checkouts must rebuild the manifest to know which objects
+  // were skipped; the fast path returns an empty skipped list and would
+  // omit gaps from the partial report.
+  if (ctx.partial) return undefined;
   const fast = await exactHeadFastPath(
     ctx.root,
     ctx.requested,

--- a/packages/adt-flow/src/types.ts
+++ b/packages/adt-flow/src/types.ts
@@ -60,7 +60,19 @@ export interface FlowCheckoutInput {
   root: string;
   transports: string[];
   mode?: FlowCheckoutMode;
+  /**
+   * Materialize only manifest entries with exact source boundaries. This is an
+   * explicit caller opt-in; ordinary checkout remains fail-closed.
+   */
+  partial?: boolean;
   config: FlowConfig;
+}
+
+export interface FlowSkippedObject {
+  object: string;
+  component: string;
+  diagnostic: string;
+  sourceTransport?: string;
 }
 
 export interface FlowCheckoutResult {
@@ -72,11 +84,7 @@ export interface FlowCheckoutResult {
   removed: string[];
   unchanged: string[];
   descriptors: string[];
-  skipped: Array<{
-    object: string;
-    component: string;
-    diagnostic: string;
-  }>;
+  skipped: FlowSkippedObject[];
   sapCalls: { manifest: number; metadata: number; source: number };
   fastPath: 'exact-head' | 'indexed-components' | 'none';
 }

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -10,16 +10,61 @@ import type {
 } from '@abapify/adt-plugin';
 import { createFlowCommand } from '../src/commands/flow';
 
-function leaf(command: CliCommandPlugin): CliCommandPlugin {
-  return command.subcommands?.[0]?.subcommands?.[0] as CliCommandPlugin;
-}
-
 const format = {
   id: 'abapgit',
   description: 'test',
   supportedTypes: ['CLAS'],
   getHandler: vi.fn(),
 } satisfies FormatPlugin;
+
+function leaf(command: CliCommandPlugin): CliCommandPlugin {
+  return command.subcommands?.[0]?.subcommands?.[0] as CliCommandPlugin;
+}
+
+const emptyCheckoutResult = {
+  mode: 'head' as const,
+  requestedTransports: ['DEVK900001'],
+  scopeTransports: ['DEVK900001'],
+  changed: [],
+  moved: [],
+  removed: [],
+  unchanged: [],
+  descriptors: [],
+  skipped: [],
+  sapCalls: { manifest: 1, metadata: 1, source: 1 },
+  fastPath: 'none' as const,
+};
+
+function makeCheckout(
+  overrides: Partial<typeof emptyCheckoutResult> = {},
+): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => ({ ...emptyCheckoutResult, ...overrides }));
+}
+
+function makeCommand(checkout: ReturnType<typeof vi.fn>) {
+  return createFlowCommand({
+    getFormat: vi.fn(() => format),
+    createService: vi.fn(() => ({ checkout })),
+  });
+}
+
+function makeContext(root: string): CliContext {
+  return {
+    cwd: root,
+    config: { flow: { format: { id: 'abapgit' } } },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getAdtClient: vi.fn(async () => ({}) as AdtClient),
+  } satisfies CliContext;
+}
+
+async function withTempRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+  try {
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
 
 describe('flow CLI command', () => {
   it('exposes an explicit flow checkout tr hierarchy and applies base mode', async () => {
@@ -106,40 +151,23 @@ describe('flow CLI command', () => {
   });
 
   it('writes a deterministic partial report only after a successful partial checkout', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
     const report = 'tmp/analysis/import-gaps.json';
-    const checkout = vi.fn(async () => ({
-      mode: 'head' as const,
-      requestedTransports: ['DEVK900001'],
-      scopeTransports: ['DEVK900001'],
+    const skipped = [
+      {
+        object: 'CLAS/ZCL_INEXACT',
+        component: 'main',
+        diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+        sourceTransport: 'DEVK900001',
+      },
+    ];
+    const checkout = makeCheckout({
       changed: ['src/zcl_sample.clas.abap'],
-      moved: [],
-      removed: [],
-      unchanged: [],
-      descriptors: [],
-      skipped: [
-        {
-          object: 'CLAS/ZCL_INEXACT',
-          component: 'main',
-          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
-          sourceTransport: 'DEVK900001',
-        },
-      ],
-      sapCalls: { manifest: 1, metadata: 1, source: 1 },
-      fastPath: 'none' as const,
-    }));
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
+      skipped,
     });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+    const command = makeCommand(checkout);
 
-    try {
+    await withTempRoot(async (root) => {
+      const ctx = makeContext(root);
       await leaf(command).execute?.(
         { transport: 'DEVK900001', partial: true, partialReport: report },
         ctx,
@@ -151,47 +179,17 @@ describe('flow CLI command', () => {
       expect(JSON.parse(await readFile(join(root, report), 'utf8'))).toEqual({
         schemaVersion: 1,
         requestedTransports: ['DEVK900001'],
-        skipped: [
-          {
-            object: 'CLAS/ZCL_INEXACT',
-            component: 'main',
-            diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
-            sourceTransport: 'DEVK900001',
-          },
-        ],
+        skipped,
       });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects --partial-report targeting the checkout root directory', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
-    const checkout = vi.fn(async () => ({
-      mode: 'head' as const,
-      requestedTransports: ['DEVK900001'],
-      scopeTransports: ['DEVK900001'],
-      changed: [],
-      moved: [],
-      removed: [],
-      unchanged: [],
-      descriptors: [],
-      skipped: [],
-      sapCalls: { manifest: 1, metadata: 1, source: 1 },
-      fastPath: 'none' as const,
-    }));
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
-    });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+    const checkout = makeCheckout();
+    const command = makeCommand(checkout);
 
-    try {
+    await withTempRoot(async (root) => {
+      const ctx = makeContext(root);
       await expect(
         leaf(command).execute?.(
           { transport: 'DEVK900001', partial: true, partialReport: '.' },
@@ -199,38 +197,15 @@ describe('flow CLI command', () => {
         ),
       ).rejects.toMatchObject({ code: 'invalid_input' });
       expect(checkout).not.toHaveBeenCalled();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects an absolute --partial-report path', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
-    const checkout = vi.fn(async () => ({
-      mode: 'head' as const,
-      requestedTransports: ['DEVK900001'],
-      scopeTransports: ['DEVK900001'],
-      changed: [],
-      moved: [],
-      removed: [],
-      unchanged: [],
-      descriptors: [],
-      skipped: [],
-      sapCalls: { manifest: 1, metadata: 1, source: 1 },
-      fastPath: 'none' as const,
-    }));
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
-    });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+    const checkout = makeCheckout();
+    const command = makeCommand(checkout);
 
-    try {
+    await withTempRoot(async (root) => {
+      const ctx = makeContext(root);
       await expect(
         leaf(command).execute?.(
           {
@@ -242,23 +217,14 @@ describe('flow CLI command', () => {
         ),
       ).rejects.toMatchObject({ code: 'invalid_input' });
       expect(checkout).not.toHaveBeenCalled();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('serializes skipped records in deterministic order', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
     const report = 'import-gaps.json';
-    const checkout = vi.fn(async () => ({
-      mode: 'head' as const,
+    const checkout = makeCheckout({
       requestedTransports: ['DEVK900001', 'DEVK900002'],
       scopeTransports: ['DEVK900001', 'DEVK900002'],
-      changed: [],
-      moved: [],
-      removed: [],
-      unchanged: [],
-      descriptors: [],
       skipped: [
         {
           object: 'CLAS/ZCL_B',
@@ -279,21 +245,11 @@ describe('flow CLI command', () => {
           sourceTransport: 'DEVK900002',
         },
       ],
-      sapCalls: { manifest: 1, metadata: 1, source: 1 },
-      fastPath: 'none' as const,
-    }));
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
     });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+    const command = makeCommand(checkout);
 
-    try {
+    await withTempRoot(async (root) => {
+      const ctx = makeContext(root);
       await leaf(command).execute?.(
         {
           transport: 'DEVK900001,DEVK900002',
@@ -323,29 +279,18 @@ describe('flow CLI command', () => {
           sourceTransport: 'DEVK900002',
         },
       ]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('does not write a partial report when checkout rejects', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
     const report = 'import-gaps.json';
     const checkout = vi.fn(async () => {
       throw new Error('checkout failed');
     });
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
-    });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+    const command = makeCommand(checkout);
 
-    try {
+    await withTempRoot(async (root) => {
+      const ctx = makeContext(root);
       await expect(
         leaf(command).execute?.(
           { transport: 'DEVK900001', partial: true, partialReport: report },
@@ -355,38 +300,15 @@ describe('flow CLI command', () => {
       await expect(readFile(join(root, report), 'utf8')).rejects.toThrow();
       const tmpFiles = await readdir(root);
       expect(tmpFiles.filter((f) => f.endsWith('.tmp'))).toEqual([]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects --partial-report without --partial opt-in', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
-    const checkout = vi.fn(async () => ({
-      mode: 'head' as const,
-      requestedTransports: ['DEVK900001'],
-      scopeTransports: ['DEVK900001'],
-      changed: [],
-      moved: [],
-      removed: [],
-      unchanged: [],
-      descriptors: [],
-      skipped: [],
-      sapCalls: { manifest: 1, metadata: 1, source: 1 },
-      fastPath: 'none' as const,
-    }));
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
-    });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+    const checkout = makeCheckout();
+    const command = makeCommand(checkout);
 
-    try {
+    await withTempRoot(async (root) => {
+      const ctx = makeContext(root);
       await expect(
         leaf(command).execute?.(
           { transport: 'DEVK900001', partialReport: 'report.json' },
@@ -394,52 +316,23 @@ describe('flow CLI command', () => {
         ),
       ).rejects.toMatchObject({ code: 'invalid_input' });
       expect(checkout).not.toHaveBeenCalled();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it.skipIf(process.platform === 'win32')(
     'rejects --partial-report escaping via a dangling symlink',
     async () => {
+      const checkout = makeCheckout();
+      const command = makeCommand(checkout);
+
       const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
       const external = await mkdtemp(join(tmpdir(), 'adt-flow-external-'));
-      // Create a dangling symlink inside root pointing to an external dir
-      // that will be deleted to make it dangling.
       const linkPath = join(root, 'linked');
       await symlink(external, linkPath);
       await rm(external, { recursive: true, force: true });
 
-      const checkout = vi.fn(async () => ({
-        mode: 'head' as const,
-        requestedTransports: ['DEVK900001'],
-        scopeTransports: ['DEVK900001'],
-        changed: [],
-        moved: [],
-        removed: [],
-        unchanged: [],
-        descriptors: [],
-        skipped: [],
-        sapCalls: { manifest: 1, metadata: 1, source: 1 },
-        fastPath: 'none' as const,
-      }));
-      const command = createFlowCommand({
-        getFormat: vi.fn(() => format),
-        createService: vi.fn(() => ({ checkout })),
-      });
-      const ctx = {
-        cwd: root,
-        config: { flow: { format: { id: 'abapgit' } } },
-        logger: {
-          debug: vi.fn(),
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
-        getAdtClient: vi.fn(async () => ({}) as AdtClient),
-      } satisfies CliContext;
-
       try {
+        const ctx = makeContext(root);
         await expect(
           leaf(command).execute?.(
             {

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { AdtClient } from '@abapify/adt-client';
@@ -370,6 +370,56 @@ describe('flow CLI command', () => {
       await expect(
         leaf(command).execute?.(
           { transport: 'DEVK900001', partialReport: 'report.json' },
+          ctx,
+        ),
+      ).rejects.toMatchObject({ code: 'invalid_input' });
+      expect(checkout).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --partial-report escaping via a dangling symlink', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const external = await mkdtemp(join(tmpdir(), 'adt-flow-external-'));
+    // Create a dangling symlink inside root pointing to an external dir
+    // that will be deleted to make it dangling.
+    const linkPath = join(root, 'linked');
+    await symlink(external, linkPath);
+    await rm(external, { recursive: true, force: true });
+
+    const checkout = vi.fn(async () => ({
+      mode: 'head' as const,
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      changed: [],
+      moved: [],
+      removed: [],
+      unchanged: [],
+      descriptors: [],
+      skipped: [],
+      sapCalls: { manifest: 1, metadata: 1, source: 1 },
+      fastPath: 'none' as const,
+    }));
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await expect(
+        leaf(command).execute?.(
+          {
+            transport: 'DEVK900001',
+            partial: true,
+            partialReport: 'linked/new/report.json',
+          },
           ctx,
         ),
       ).rejects.toMatchObject({ code: 'invalid_input' });

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import type { AdtClient } from '@abapify/adt-client';
 import type {
   CliCommandPlugin,
@@ -69,13 +72,14 @@ describe('flow CLI command', () => {
       root: '/workspace',
       transports: ['DEVK900002', 'DEVK900001'],
       mode: 'base',
+      partial: false,
       config: ctx.config.flow,
     });
     expect(info).toHaveBeenCalledWith(
       expect.stringContaining('1 changed, 0 moved, 0 removed'),
     );
     expect(warn).toHaveBeenCalledWith(
-      'Skipped unsupported object TABD/PAYHX01 (object; OBJECT_TYPE_UNSUPPORTED).',
+      'Skipped object TABD/PAYHX01 (object; OBJECT_TYPE_UNSUPPORTED).',
     );
     expect(warn).toHaveBeenCalledTimes(1);
   });
@@ -99,5 +103,65 @@ describe('flow CLI command', () => {
       leaf(command).execute?.({ transport: 'DEVK900001' }, ctx),
     ).rejects.toMatchObject({ code: 'configuration_invalid' });
     expect(getAdtClient).not.toHaveBeenCalled();
+  });
+
+  it('writes a deterministic partial report only after a successful partial checkout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const report = join(root, 'tmp', 'analysis', 'import-gaps.json');
+    const checkout = vi.fn(async () => ({
+      mode: 'head' as const,
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      changed: ['src/zcl_sample.clas.abap'],
+      moved: [],
+      removed: [],
+      unchanged: [],
+      descriptors: [],
+      skipped: [
+        {
+          object: 'CLAS/ZCL_INEXACT',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900001',
+        },
+      ],
+      sapCalls: { manifest: 1, metadata: 1, source: 1 },
+      fastPath: 'none' as const,
+    }));
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await leaf(command).execute?.(
+        { transport: 'DEVK900001', partial: true, 'partial-report': report },
+        ctx,
+      );
+
+      expect(checkout).toHaveBeenCalledWith(
+        expect.objectContaining({ partial: true }),
+      );
+      expect(JSON.parse(await readFile(report, 'utf8'))).toEqual({
+        schemaVersion: 1,
+        requestedTransports: ['DEVK900001'],
+        skipped: [
+          {
+            object: 'CLAS/ZCL_INEXACT',
+            component: 'main',
+            diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+            sourceTransport: 'DEVK900001',
+          },
+        ],
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -252,8 +252,8 @@ describe('flow CLI command', () => {
     const report = 'import-gaps.json';
     const checkout = vi.fn(async () => ({
       mode: 'head' as const,
-      requestedTransports: ['DEVK900001'],
-      scopeTransports: ['DEVK900001'],
+      requestedTransports: ['DEVK900001', 'DEVK900002'],
+      scopeTransports: ['DEVK900001', 'DEVK900002'],
       changed: [],
       moved: [],
       removed: [],
@@ -264,11 +264,19 @@ describe('flow CLI command', () => {
           object: 'CLAS/ZCL_B',
           component: 'main',
           diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900002',
         },
         {
           object: 'CLAS/ZCL_A',
           component: 'main',
           diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900001',
+        },
+        {
+          object: 'CLAS/ZCL_A',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900002',
         },
       ],
       sapCalls: { manifest: 1, metadata: 1, source: 1 },
@@ -287,7 +295,11 @@ describe('flow CLI command', () => {
 
     try {
       await leaf(command).execute?.(
-        { transport: 'DEVK900001', partial: true, partialReport: report },
+        {
+          transport: 'DEVK900001,DEVK900002',
+          partial: true,
+          partialReport: report,
+        },
         ctx,
       );
       const parsed = JSON.parse(await readFile(join(root, report), 'utf8'));
@@ -296,11 +308,19 @@ describe('flow CLI command', () => {
           object: 'CLAS/ZCL_A',
           component: 'main',
           diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900001',
+        },
+        {
+          object: 'CLAS/ZCL_A',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900002',
         },
         {
           object: 'CLAS/ZCL_B',
           component: 'main',
           diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900002',
         },
       ]);
     } finally {
@@ -379,53 +399,61 @@ describe('flow CLI command', () => {
     }
   });
 
-  it('rejects --partial-report escaping via a dangling symlink', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
-    const external = await mkdtemp(join(tmpdir(), 'adt-flow-external-'));
-    // Create a dangling symlink inside root pointing to an external dir
-    // that will be deleted to make it dangling.
-    const linkPath = join(root, 'linked');
-    await symlink(external, linkPath);
-    await rm(external, { recursive: true, force: true });
+  it.skipIf(process.platform === 'win32')(
+    'rejects --partial-report escaping via a dangling symlink',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+      const external = await mkdtemp(join(tmpdir(), 'adt-flow-external-'));
+      // Create a dangling symlink inside root pointing to an external dir
+      // that will be deleted to make it dangling.
+      const linkPath = join(root, 'linked');
+      await symlink(external, linkPath);
+      await rm(external, { recursive: true, force: true });
 
-    const checkout = vi.fn(async () => ({
-      mode: 'head' as const,
-      requestedTransports: ['DEVK900001'],
-      scopeTransports: ['DEVK900001'],
-      changed: [],
-      moved: [],
-      removed: [],
-      unchanged: [],
-      descriptors: [],
-      skipped: [],
-      sapCalls: { manifest: 1, metadata: 1, source: 1 },
-      fastPath: 'none' as const,
-    }));
-    const command = createFlowCommand({
-      getFormat: vi.fn(() => format),
-      createService: vi.fn(() => ({ checkout })),
-    });
-    const ctx = {
-      cwd: root,
-      config: { flow: { format: { id: 'abapgit' } } },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      getAdtClient: vi.fn(async () => ({}) as AdtClient),
-    } satisfies CliContext;
+      const checkout = vi.fn(async () => ({
+        mode: 'head' as const,
+        requestedTransports: ['DEVK900001'],
+        scopeTransports: ['DEVK900001'],
+        changed: [],
+        moved: [],
+        removed: [],
+        unchanged: [],
+        descriptors: [],
+        skipped: [],
+        sapCalls: { manifest: 1, metadata: 1, source: 1 },
+        fastPath: 'none' as const,
+      }));
+      const command = createFlowCommand({
+        getFormat: vi.fn(() => format),
+        createService: vi.fn(() => ({ checkout })),
+      });
+      const ctx = {
+        cwd: root,
+        config: { flow: { format: { id: 'abapgit' } } },
+        logger: {
+          debug: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        getAdtClient: vi.fn(async () => ({}) as AdtClient),
+      } satisfies CliContext;
 
-    try {
-      await expect(
-        leaf(command).execute?.(
-          {
-            transport: 'DEVK900001',
-            partial: true,
-            partialReport: 'linked/new/report.json',
-          },
-          ctx,
-        ),
-      ).rejects.toMatchObject({ code: 'invalid_input' });
-      expect(checkout).not.toHaveBeenCalled();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
+      try {
+        await expect(
+          leaf(command).execute?.(
+            {
+              transport: 'DEVK900001',
+              partial: true,
+              partialReport: 'linked/new/report.json',
+            },
+            ctx,
+          ),
+        ).rejects.toMatchObject({ code: 'invalid_input' });
+        expect(checkout).not.toHaveBeenCalled();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -107,7 +107,7 @@ describe('flow CLI command', () => {
 
   it('writes a deterministic partial report only after a successful partial checkout', async () => {
     const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
-    const report = join(root, 'tmp', 'analysis', 'import-gaps.json');
+    const report = 'tmp/analysis/import-gaps.json';
     const checkout = vi.fn(async () => ({
       mode: 'head' as const,
       requestedTransports: ['DEVK900001'],
@@ -148,7 +148,7 @@ describe('flow CLI command', () => {
       expect(checkout).toHaveBeenCalledWith(
         expect.objectContaining({ partial: true }),
       );
-      expect(JSON.parse(await readFile(report, 'utf8'))).toEqual({
+      expect(JSON.parse(await readFile(join(root, report), 'utf8'))).toEqual({
         schemaVersion: 1,
         requestedTransports: ['DEVK900001'],
         skipped: [
@@ -199,6 +199,110 @@ describe('flow CLI command', () => {
         ),
       ).rejects.toMatchObject({ code: 'invalid_input' });
       expect(checkout).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an absolute --partial-report path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const checkout = vi.fn(async () => ({
+      mode: 'head' as const,
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      changed: [],
+      moved: [],
+      removed: [],
+      unchanged: [],
+      descriptors: [],
+      skipped: [],
+      sapCalls: { manifest: 1, metadata: 1, source: 1 },
+      fastPath: 'none' as const,
+    }));
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await expect(
+        leaf(command).execute?.(
+          {
+            transport: 'DEVK900001',
+            partial: true,
+            partialReport: join(root, 'escape.json'),
+          },
+          ctx,
+        ),
+      ).rejects.toMatchObject({ code: 'invalid_input' });
+      expect(checkout).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes skipped records in deterministic order', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const report = 'import-gaps.json';
+    const checkout = vi.fn(async () => ({
+      mode: 'head' as const,
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      changed: [],
+      moved: [],
+      removed: [],
+      unchanged: [],
+      descriptors: [],
+      skipped: [
+        {
+          object: 'CLAS/ZCL_B',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+        },
+        {
+          object: 'CLAS/ZCL_A',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+        },
+      ],
+      sapCalls: { manifest: 1, metadata: 1, source: 1 },
+      fastPath: 'none' as const,
+    }));
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await leaf(command).execute?.(
+        { transport: 'DEVK900001', partial: true, partialReport: report },
+        ctx,
+      );
+      const parsed = JSON.parse(await readFile(join(root, report), 'utf8'));
+      expect(parsed.skipped).toEqual([
+        {
+          object: 'CLAS/ZCL_A',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+        },
+        {
+          object: 'CLAS/ZCL_B',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+        },
+      ]);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -339,4 +339,43 @@ describe('flow CLI command', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('rejects --partial-report without --partial opt-in', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const checkout = vi.fn(async () => ({
+      mode: 'head' as const,
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      changed: [],
+      moved: [],
+      removed: [],
+      unchanged: [],
+      descriptors: [],
+      skipped: [],
+      sapCalls: { manifest: 1, metadata: 1, source: 1 },
+      fastPath: 'none' as const,
+    }));
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await expect(
+        leaf(command).execute?.(
+          { transport: 'DEVK900001', partialReport: 'report.json' },
+          ctx,
+        ),
+      ).rejects.toMatchObject({ code: 'invalid_input' });
+      expect(checkout).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { AdtClient } from '@abapify/adt-client';
@@ -303,6 +303,38 @@ describe('flow CLI command', () => {
           diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
         },
       ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write a partial report when checkout rejects', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const report = 'import-gaps.json';
+    const checkout = vi.fn(async () => {
+      throw new Error('checkout failed');
+    });
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await expect(
+        leaf(command).execute?.(
+          { transport: 'DEVK900001', partial: true, partialReport: report },
+          ctx,
+        ),
+      ).rejects.toThrow('checkout failed');
+      await expect(readFile(join(root, report), 'utf8')).rejects.toThrow();
+      const tmpFiles = await readdir(root);
+      expect(tmpFiles.filter((f) => f.endsWith('.tmp'))).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -164,4 +164,43 @@ describe('flow CLI command', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('rejects --partial-report targeting the checkout root directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+    const checkout = vi.fn(async () => ({
+      mode: 'head' as const,
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      changed: [],
+      moved: [],
+      removed: [],
+      unchanged: [],
+      descriptors: [],
+      skipped: [],
+      sapCalls: { manifest: 1, metadata: 1, source: 1 },
+      fastPath: 'none' as const,
+    }));
+    const command = createFlowCommand({
+      getFormat: vi.fn(() => format),
+      createService: vi.fn(() => ({ checkout })),
+    });
+    const ctx = {
+      cwd: root,
+      config: { flow: { format: { id: 'abapgit' } } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getAdtClient: vi.fn(async () => ({}) as AdtClient),
+    } satisfies CliContext;
+
+    try {
+      await expect(
+        leaf(command).execute?.(
+          { transport: 'DEVK900001', partial: true, partialReport: '.' },
+          ctx,
+        ),
+      ).rejects.toMatchObject({ code: 'invalid_input' });
+      expect(checkout).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -141,7 +141,7 @@ describe('flow CLI command', () => {
 
     try {
       await leaf(command).execute?.(
-        { transport: 'DEVK900001', partial: true, 'partial-report': report },
+        { transport: 'DEVK900001', partial: true, partialReport: report },
         ctx,
       );
 

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+} from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { AdtClient } from '@abapify/adt-client';
@@ -339,6 +346,70 @@ describe('flow CLI command', () => {
               transport: 'DEVK900001',
               partial: true,
               partialReport: 'linked/new/report.json',
+            },
+            ctx,
+          ),
+        ).rejects.toMatchObject({ code: 'invalid_input' });
+        expect(checkout).not.toHaveBeenCalled();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects --partial-report when the target file is a symlink escaping the checkout',
+    async () => {
+      const checkout = makeCheckout();
+      const command = makeCommand(checkout);
+
+      const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+      const external = await mkdtemp(join(tmpdir(), 'adt-flow-external-'));
+      const reportPath = join(root, 'report.json');
+      // Pre-create the report file as a symlink pointing outside root.
+      await symlink(join(external, 'evil.json'), reportPath);
+
+      try {
+        const ctx = makeContext(root);
+        await expect(
+          leaf(command).execute?.(
+            {
+              transport: 'DEVK900001',
+              partial: true,
+              partialReport: 'report.json',
+            },
+            ctx,
+          ),
+        ).rejects.toMatchObject({ code: 'invalid_input' });
+        expect(checkout).not.toHaveBeenCalled();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+        await rm(external, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects --partial-report path containing a symlink loop',
+    async () => {
+      const checkout = makeCheckout();
+      const command = makeCommand(checkout);
+
+      const root = await mkdtemp(join(tmpdir(), 'adt-flow-command-'));
+      // Create a symlink loop: root/loop/a -> root/loop/b, root/loop/b -> root/loop/a
+      const loopDir = join(root, 'loop');
+      await mkdir(loopDir);
+      await symlink(join(loopDir, 'b'), join(loopDir, 'a'));
+      await symlink(join(loopDir, 'a'), join(loopDir, 'b'));
+
+      try {
+        const ctx = makeContext(root);
+        await expect(
+          leaf(command).execute?.(
+            {
+              transport: 'DEVK900001',
+              partial: true,
+              partialReport: 'loop/a/report.json',
             },
             ctx,
           ),

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -778,6 +778,7 @@ describe('transport checkout', () => {
         object: 'TABD/PAYHX01',
         component: 'object',
         diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+        sourceTransport: 'DEVK900001',
       },
     ]);
     expect(result.changed).toContain('src/feature/zcl_sample.clas.abap');
@@ -806,6 +807,7 @@ describe('transport checkout', () => {
         object: 'METH/ZCL_TR_LOAN_CUSTOM_ENTITY FETCH_DATA_LIST',
         component: 'object',
         diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+        sourceTransport: 'DEVK900001',
       },
     ]);
     expect(result.changed).toEqual([
@@ -997,6 +999,7 @@ describe('transport checkout', () => {
         object: 'TABD/PAYHX01',
         component: 'object',
         diagnostic: 'OBJECT_METADATA_LOAD_FAILED',
+        sourceTransport: 'DEVK900001',
       },
     ]);
     expect(ports.loadObject).not.toHaveBeenCalled();
@@ -1033,6 +1036,7 @@ describe('transport checkout', () => {
         object: 'TABD/PAYHX01',
         component: 'object',
         diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+        sourceTransport: 'DEVK900001',
       },
     ]);
     expect(ports.loadObject).toHaveBeenCalledTimes(1);

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -711,6 +711,51 @@ describe('transport checkout', () => {
     expect(ports.loadObject).not.toHaveBeenCalled();
   });
 
+  it('materializes the exact subset only when partial mode explicitly opts in', async () => {
+    const workspace = await root();
+    const current = manifest('modified', version('before'), version('after'));
+    current.entries.push({
+      object: {
+        pgmid: 'R3TR',
+        type: 'CLAS',
+        name: 'ZCL_ZZZ_INEXACT',
+        packageName: 'ZROOT_FEATURE',
+      },
+      component: { id: 'main' },
+      sourceTransport: 'DEVK900001',
+      changeKind: 'ambiguous',
+      exact: false,
+      diagnostic: {
+        code: 'SOURCE_HISTORY_INTERVENING_VERSION',
+        message: 'A version from another transport occurs inside this scope.',
+      },
+    });
+    const ports = dependencies(() => current);
+
+    const result = await createAdtFlowService(ports).checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config,
+      partial: true,
+    });
+
+    expect(result.changed).toContain('src/feature/zcl_sample.clas.abap');
+    expect(result.skipped).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          object: 'CLAS/ZCL_ZZZ_INEXACT',
+          component: 'main',
+          diagnostic: 'SOURCE_HISTORY_INTERVENING_VERSION',
+          sourceTransport: 'DEVK900001',
+        }),
+      ]),
+    );
+    const descriptor = JSON.parse(
+      await readFile(join(workspace, '.adt/tr/DEVK900001.json'), 'utf8'),
+    );
+    expect(descriptor.incomplete).toBe(true);
+  });
+
   it('skips unsupported objects while materializing supported objects from the same transport', async () => {
     const workspace = await root();
     const current = manifest('modified', version('before'), version('after'));


### PR DESCRIPTION
## **User description**
## Summary

Adds an opt-in partial transport checkout mode for `flow checkout tr`.

- preserves default fail-closed behavior
- materializes only exact source objects when `--partial` is set
- emits an atomic JSON report through `--partial-report`
- keeps unsafe or inexact source components omitted rather than selecting another version

## Validation

- focused flow command and service tests pass
- `nx run adt-flow:build` passes

The follow-up fix ensures Commander runtime option parsing honours `--partial-report`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in partial checkout mode for `flow checkout tr` that materializes exact transport objects and reports source-history gaps instead of failing the run. Default checkouts stay fail-closed.

- `--partial-report <file>` requires `--partial`, writes deterministic JSON atomically after a successful checkout, and rejects absolute, root, traversal, and symlink-escaping paths, including dangling symlinks, symlink loops, and existing symlinks at the target.
- Partial checkouts rebuild the manifest instead of using the exact-head fast path so skipped objects are captured; their descriptors are marked incomplete and cannot be reused by the fast path.
- Reports list requested transports and skipped objects with source transports, application-component filtering, and diagnostics.
- Standard checkouts keep existing behavior and no incomplete marker. Exports `FlowSkippedObject`; incomplete markers accept only `true`.

<sup>Written for commit 19947a5e94de49dfe8845e4290445092d2018589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional partial checkout mode to materialize available exact objects while reporting skipped objects.
  * Added deterministic JSON checkout reports with schema details, requested transports, and skipped objects.
  * Transport descriptors now indicate when a checkout is incomplete.

* **Validation**
  * Partial reports require partial mode and valid repository-relative paths, including protection against symlink escapes.

* **Bug Fixes**
  * Prevented incomplete checkout boundaries from being reused as complete results.
  * Preserved all-or-nothing behavior for standard checkouts.
  * Reports are written only after successful checkouts and cleaned up when checkout fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Allow partial transport checkouts with reliable gap reports

### What Changed
- Adds an explicit partial checkout option that materializes only objects with exact source history while preserving fail-closed behavior by default
- Adds optional JSON reports listing skipped objects, their source transports, components, and diagnostics
- Reports are written only after successful checkouts, in deterministic order, using repository-relative paths protected against traversal and symlink escapes
- Incomplete checkout descriptors cannot be reused as complete exact-head boundaries
- Checkout results and warnings now identify the source transport for skipped objects

### Impact
`✅ Partial checkouts without unsafe source selection`
`✅ Deterministic transport gap reports`
`✅ Prevented report writes outside the checkout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
