### PR TITLE
fix(adk): keep FUGR function module sources distinct

### DIFF
--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -452,7 +452,18 @@ async function discoverObjectSourceHistory(
     ...object,
     ...(packageName ? { packageName } : {}),
   };
-  const components = discoverSourceComponents(metadata, objectUri);
+  const components = discoverSourceComponents(metadata, objectUri).map(
+    (component) =>
+      component.id === 'main' && object.type === 'FUGR/FF'
+        ? {
+            ...component,
+            // A function module is a child of its function group. The
+            // generic root-source id is only unique within one object, so
+            // use the FM name before the flow source map is assembled.
+            id: object.name.toLowerCase(),
+          }
+        : component,
+  );
   if (components.length === 0) {
     throw new ObjectSourceHistoryError(
       'SOURCE_COMPONENTS_UNAVAILABLE',

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -452,18 +452,7 @@ async function discoverObjectSourceHistory(
     ...object,
     ...(packageName ? { packageName } : {}),
   };
-  const components = discoverSourceComponents(metadata, objectUri).map(
-    (component) =>
-      component.id === 'main' && object.type === 'FUGR/FF'
-        ? {
-            ...component,
-            // A function module is a child of its function group. The
-            // generic root-source id is only unique within one object, so
-            // use the FM name before the flow source map is assembled.
-            id: object.name.toLowerCase(),
-          }
-        : component,
-  );
+  const components = discoverSourceComponents(metadata, objectUri);
   if (components.length === 0) {
     throw new ObjectSourceHistoryError(
       'SOURCE_COMPONENTS_UNAVAILABLE',
@@ -986,8 +975,22 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
       : {}),
   };
 
+  // A function module is a child of its function group. The generic
+  // root-source id is only unique within one object, so use the FM name
+  // as the source-map key. This rename is scoped to the transport
+  // manifest (the flow source map) so the public
+  // listObjectSourceVersions API keeps returning the real root id.
+  const manifestComponents =
+    repository.type === 'FUGR/FF'
+      ? discovery.components.map((component) =>
+          component.id === 'main'
+            ? { ...component, id: repository.name.toLowerCase() }
+            : component,
+        )
+      : discovery.components;
+
   const entries: TransportSourceManifestEntry[] = [];
-  for (const component of discovery.components) {
+  for (const component of manifestComponents) {
     const publicComponent: TransportSourceManifestComponent = {
       id: component.id,
       ...(component.sourceUri ? { sourceUri: component.sourceUri } : {}),

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -513,6 +513,31 @@ describe('listObjectSourceVersions', () => {
     expect(listVersions).not.toHaveBeenCalled();
   });
 
+  it('keeps the root component id "main" for a FUGR/FF function module', async () => {
+    transportObject({
+      name: 'ZFM_KEEP_MAIN',
+      type: 'FUGR/FF',
+      objectUri:
+        '/sap/bc/adt/functions/groups/zfg_keep_main/fmodules/zfm_keep_main',
+      metadata: rootSourceMetadata(),
+    });
+    const head = version('00001', 0, ['DEVK900002']);
+    const listVersions = vi.fn().mockResolvedValue([head]);
+    const { ctx } = contextWithVersions(listVersions);
+
+    const result = await listObjectSourceVersions(
+      'ZFM_KEEP_MAIN',
+      'FUGR/FF',
+      { component: 'main' },
+      ctx,
+    );
+
+    expect(result.components.map((component) => component.id)).toEqual([
+      'main',
+    ]);
+    expect(result.components[0]?.versions).toEqual([head]);
+  });
+
   it('returns a stable diagnostic for a component without version history', async () => {
     transportObject({
       name: 'ZNO_HISTORY',

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -982,6 +982,61 @@ describe('buildTransportSourceManifest', () => {
     ]);
   });
 
+  it('keeps separate source components for two function modules in one group', async () => {
+    const functionNames = [
+      'ZFM_PY_LEAN_PAYMEDIUM_EVENT_21',
+      'ZFM_PY_LEAN_PAYMEDIUM_EVENT_41',
+    ];
+    const functionModules = functionNames.map((name) => {
+      const functionModule = transportObject({
+        name,
+        pgmid: 'LIMU',
+        type: 'FUNC',
+        wbtype: 'FUGR/FF',
+        objectUri: '',
+        factoryName: 'ZFG_PY_LEAN',
+        metadata: rootSourceMetadata(),
+      });
+      functionModuleObject('ZFG_PY_LEAN', name);
+      return functionModule;
+    });
+    mockResolution(
+      functionModules,
+      ['S0DK955760', 'S0DK955760'],
+      ['S0DK955760'],
+    );
+    const { ctx, quickSearch } = contextWithVersions(
+      vi.fn().mockResolvedValue([version('00001', 0, ['S0DK955760'])]),
+    );
+    quickSearch.mockImplementation(async ({ query }: { query: string }) => ({
+      objectReferences: {
+        objectReference: [
+          {
+            name: query,
+            uri: `/sap/bc/adt/functions/groups/zfg_py_lean/fmodules/${query.toLowerCase()}`,
+          },
+        ],
+      },
+    }));
+
+    const manifest = await buildTransportSourceManifest(
+      ['S0DK955760'],
+      {},
+      ctx,
+    );
+
+    expect(manifest.entries).toHaveLength(2);
+    expect(manifest.entries.map((entry) => entry.component.id)).toEqual(
+      functionNames.map((name) => name.toLowerCase()),
+    );
+    expect(manifest.entries.map((entry) => entry.component.sourceUri)).toEqual(
+      functionNames.map(
+        (name) =>
+          `/sap/bc/adt/functions/groups/zfg_py_lean/fmodules/${name.toLowerCase()}/source/main`,
+      ),
+    );
+  });
+
   it('ignores R3TR SUSK authorization-maintenance assignments as non-source entries', async () => {
     const authorizationAssignment = transportObject({
       name: 'Z_CONCUR_RECON',

--- a/packages/adt-plugin-abapgit/tests/format-materialization.test.ts
+++ b/packages/adt-plugin-abapgit/tests/format-materialization.test.ts
@@ -139,6 +139,54 @@ describe('abapGit format materialization', () => {
     );
   });
 
+  it('materializes separate function module sources in a function group', async () => {
+    const fm21 = 'function zfm_py_lean_paymedium_event_21.';
+    const fm41 = 'function zfm_py_lean_paymedium_event_41.';
+    const result = await abapgitFormatPlugin.materialize!({
+      object: {
+        name: 'ZFG_PY_LEAN',
+        description: 'Payment medium events',
+        dataSync: {
+          name: 'ZFG_PY_LEAN',
+          description: 'Payment medium events',
+          fixPointArithmetic: false,
+        },
+        getSource: async () => {
+          throw new Error('TOP source must not be read');
+        },
+      },
+      objectType: 'FUGR',
+      packagePath: ['ZROOT', 'ZROOT_FEATURE'],
+      sources: {
+        zfm_py_lean_paymedium_event_21: fm21,
+        zfm_py_lean_paymedium_event_41: fm41,
+      },
+      formatOptions: { folderLogic: 'prefix' },
+    });
+
+    assert.deepStrictEqual(
+      result.files
+        .filter(({ path }) => path.includes('.fugr.zfm_'))
+        .map(({ path, sourceComponent, content }) => ({
+          path,
+          sourceComponent,
+          content,
+        })),
+      [
+        {
+          path: 'src/feature/zfg_py_lean.fugr.zfm_py_lean_paymedium_event_21.abap',
+          sourceComponent: 'zfm_py_lean_paymedium_event_21',
+          content: fm21,
+        },
+        {
+          path: 'src/feature/zfg_py_lean.fugr.zfm_py_lean_paymedium_event_41.abap',
+          sourceComponent: 'zfm_py_lean_paymedium_event_41',
+          content: fm41,
+        },
+      ],
+    );
+  });
+
   it('materializes only supplied class components with deterministic paths', async () => {
     const object = {
       name: 'ZCL_FLOW_EXAMPLE',


### PR DESCRIPTION
## **User description**
## Summary

Fix FUGR source materialization when a transport contains multiple function
modules from the same function group.

The ADT source manifest exposed each function module's root source component
with the generic `main` id. `adt-flow` uses that id as the source-map key, so
two function modules in one FUGR collided and one source body replaced the
other. The abapGit FUGR handler already supports explicit per-FM source keys
and writes them as separate files.

For `FUGR/FF` objects, this change makes the root source component id the
lowercase function-module name. Other object types keep their existing
component ids.

## Verification

- Regression test reproduces two `LIMU/FUNC` entries in one FUGR and verifies
  both distinct source component ids and source URIs.
- Format materialization regression test verifies separate files:
  `src/feature/zfg_py_lean.fugr.zfm_py_lean_paymedium_event_21.abap` and
  `src/feature/zfg_py_lean.fugr.zfm_py_lean_paymedium_event_41.abap`.
- Targeted ADK test: 34 passed.
- Format materialization test: 1 passed.
- `git diff --check`: passed.

## Context

- S0D work item: https://gitlab.com/booking-com/finsys-devops/s0d/-/work_items/1
- Reproduction MR: https://gitlab.com/booking-com/finsys-devops/s0d/-/merge_requests/109

## Upstream handoff

- GitLab mirror Draft MR: https://gitlab.com/booking-com/finsys-devops/adt-cli/-/merge_requests/71
- Mirror pipeline: https://gitlab.com/booking-com/finsys-devops/adt-cli/-/pipelines/2827256059 (passed)
- Preview-image downstream pipeline: https://gitlab.com/booking-com/finsys-devops/adt-cli-cicd/-/pipelines/2827256668 (passed)

The GitHub fork branch has the same source tree as the mirror branch. Commit
metadata differs only to satisfy each host's email privacy/verification
policy; no source files differ.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes FUGR source materialization so multiple function modules in one function group no longer collide in the ADK source manifest. Previously, each function module's root source component was exposed with the generic `main` id, causing `adt-flow` source-map collisions that replaced one module's source body with another's.

**Bug Fixes**
- Renames the root source component id to the lowercase function-module name only in the transport manifest; the public `listObjectSourceVersions` API still returns the real `main` id.
- Adds regression tests for two function modules in one FUGR, separate file materialization, and `listObjectSourceVersions` with `component: 'main'`.

<sup>Written for commit 2adeb9afd314287a52ed754fe67a3e6d52fbeffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Function module source manifests now retain distinct identifiers and generate separate entries and source paths.
  * Public source-version listings now preserve the root component identifier for function modules.
  * Function group materialization now emits separate ABAP files for each function module without reading the group-level source.

* **Tests**
  * Added coverage for root identifier preservation, multiple function modules, and separate ABAP file materialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep function module sources separate within function groups

### What Changed
- Function modules in the same function group now retain distinct source entries and materialize into separate files.
- Public source-version lookups continue to use the root component id `main`.
- Added regression coverage for separate function module files, transport manifests, and source-version lookups.

### Impact
`✅ No overwritten function module sources`
`✅ Separate files for each function module`
`✅ Working source history lookups for function groups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
