### PR TITLE
fix(ts-xsd): quote XML property names in generated types

### DIFF
--- a/packages/ts-xsd/src/codegen/ts-morph.ts
+++ b/packages/ts-xsd/src/codegen/ts-morph.ts
@@ -65,6 +65,12 @@ export interface SchemaSourceFileResult {
 // Helpers
 // =============================================================================
 
+function propertyName(name: string): string {
+  return /^[\p{ID_Start}$_][\p{ID_Continue}$\u200C\u200D]*$/u.test(name)
+    ? name
+    : JSON.stringify(name);
+}
+
 function deriveRootTypeName(filename: string | undefined): string | undefined {
   if (!filename) return undefined;
   const baseName = filename.replace(/\.xsd$/, '').replace(/^.*\//, '');
@@ -358,7 +364,7 @@ export function expandTypeToString(
         indent + '  ',
         newVisited,
       );
-      lines.push(`${indent}  ${name}${optional}: ${expanded};`);
+      lines.push(`${indent}  ${propertyName(name)}${optional}: ${expanded};`);
     }
     lines.push(`${indent}}`);
     return lines.join('\n');
@@ -689,7 +695,7 @@ function generateInterface(
     isExported: true,
     extends: extendsTypes.length > 0 ? extendsTypes : undefined,
     properties: properties.map((p) => ({
-      name: p.name,
+      name: propertyName(p.name),
       type: p.type,
       hasQuestionToken: p.hasQuestionToken,
     })),
@@ -968,7 +974,7 @@ function generateRootType(rootTypeName: string, ctx: GeneratorContext): void {
   // For multi-root: union of wrapped types { el1: Type1 } | { el2: Type2 }
   // Root type matches what parse() returns - wrapped with element name for type discrimination
   const wrappedTypes = elementNames.map(
-    (name, i) => `{ ${name}: ${elementTypes[i]} }`,
+    (name, i) => `{ ${propertyName(name)}: ${elementTypes[i]} }`,
   );
   const rootType =
     wrappedTypes.length === 1 ? wrappedTypes[0] : wrappedTypes.join(' | ');

--- a/packages/ts-xsd/tests/unit/interface-generator.test.ts
+++ b/packages/ts-xsd/tests/unit/interface-generator.test.ts
@@ -2,6 +2,81 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { generateInterfaces } from '../../src/codegen/interface-generator';
 import type { Schema } from '../../src/xsd/types';
+import { parseXsd } from '../../src/xsd/parse';
+
+describe('XML property names', () => {
+  for (const flatten of [false, true]) {
+    it(`preserves dotted and hyphenated names in ${flatten ? 'flattened types' : 'interfaces'}`, () => {
+      const schema = parseXsd(`
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          <xs:complexType name="Properties">
+            <xs:sequence>
+              <xs:element name="MZ.Sequence.EditingModeGUID" type="xs:string"/>
+              <xs:element name="preview-codec" type="xs:int" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="adobe.flag" type="xs:boolean" use="required"/>
+            <xs:attribute name="optional-flag" type="xs:boolean"/>
+          </xs:complexType>
+          <xs:complexType name="Example">
+            <xs:sequence>
+              <xs:element name="properties" type="Properties"/>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:element name="adobe.project" type="Example"/>
+        </xs:schema>
+      `);
+      const { project, sourceFile } = generateInterfaces(schema, {
+        flatten,
+        rootTypeName: 'ExampleSchema',
+        addJsDoc: false,
+      });
+      project.createSourceFile(
+        'consumer.ts',
+        `
+        import type { ExampleSchema } from './${sourceFile.getBaseNameWithoutExtension()}';
+        const project: ExampleSchema = {
+          "adobe.project": {
+            properties: {
+              "MZ.Sequence.EditingModeGUID": "editing-mode",
+              "preview-codec": [1, 2],
+              "adobe.flag": false,
+            },
+          },
+        };
+        const guid: string = project["adobe.project"].properties["MZ.Sequence.EditingModeGUID"];
+        const codecs: number[] | undefined = project["adobe.project"].properties["preview-codec"];
+        const flag: boolean | undefined = project["adobe.project"].properties["optional-flag"];
+      `,
+      );
+      assert.deepStrictEqual(
+        project.getPreEmitDiagnostics().map((d) => d.getMessageText()),
+        [],
+      );
+      const rootType = sourceFile
+        .getTypeAliasOrThrow('ExampleSchema')
+        .getType();
+      assert.deepStrictEqual(
+        rootType.getProperties().map((p) => p.getName()),
+        ['adobe.project'],
+      );
+      const root = rootType
+        .getPropertyOrThrow('adobe.project')
+        .getTypeAtLocation(sourceFile);
+      const properties = root
+        .getPropertyOrThrow('properties')
+        .getTypeAtLocation(sourceFile);
+      assert.deepStrictEqual(
+        properties.getProperties().map((p) => p.getName()),
+        [
+          'MZ.Sequence.EditingModeGUID',
+          'preview-codec',
+          'adobe.flag',
+          'optional-flag',
+        ],
+      );
+    });
+  }
+});
 
 describe('Interface Generator', () => {
   // Simple schema with one complex type

--- a/packages/ts-xsd/tests/unit/interface-generator.test.ts
+++ b/packages/ts-xsd/tests/unit/interface-generator.test.ts
@@ -5,7 +5,7 @@ import type { Schema } from '../../src/xsd/types';
 import { parseXsd } from '../../src/xsd/parse';
 
 describe('XML property names', () => {
-  for (const flatten of [false, true]) {
+  for (const flatten of [false, true] as const) {
     it(`preserves dotted and hyphenated names in ${flatten ? 'flattened types' : 'interfaces'}`, () => {
       const schema = parseXsd(`
         <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">


### PR DESCRIPTION
## **User description**
## Summary
Valid XML names containing dots or hyphens currently produce invalid TypeScript, for example `MZ.Sequence.EditingModeGUID: string`.

Quote names that are not valid identifiers when emitting interface properties, flattened properties, and root-element wrappers. Ordinary identifiers remain unchanged. No API or dependency changes.

## Verification
- Added regressions that generate both interfaces and flattened types from XSD, compile a typed consumer, and check that exact property names survive.
- All 472 package tests pass; the new regressions fail before the fix.
- Build, source typecheck, lint, and formatting pass.
- The separate test-typecheck target has a pre-existing error in `tests/integration/codegen-infer.test.ts:151`: `personSchema` is referenced but declared as `_personSchema`. Left unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ts-xsd` codegen so XSD property names containing dots or hyphens produce valid TypeScript. Previously names like `MZ.Sequence.EditingModeGUID` were emitted unquoted as invalid identifiers; now names that aren't valid identifiers are quoted in interfaces, flattened types, and root-element wrappers, while ordinary identifiers remain unchanged. No API or dependency changes.

## Verification
- Added regressions that generate both interfaces and flattened types from XSD, compile a typed consumer, and check that exact property names survive.
- All 472 package tests pass; the new regressions fail before the fix.
- Build, source typecheck, lint, and formatting pass.
- The separate test-typecheck target has a pre-existing error in `tests/integration/codegen-infer.test.ts:151`: `personSchema` is referenced but declared as `_personSchema`. Left unchanged.

<sup>Written for commit cb18b3591e29d97ed4ba49a3641a68776c107ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated TypeScript interfaces now preserve XML element and attribute names containing dots or hyphens while keeping the output valid TypeScript.
  * Improved generated property names for both flattened and nested schema representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Generate valid TypeScript for XML names containing dots and hyphens

### What Changed
- XML element, attribute, and nested property names that are not valid TypeScript identifiers are now quoted in generated types.
- Root wrappers and flattened types preserve names such as `adobe.project`, `MZ.Sequence.EditingModeGUID`, and `preview-codec` for bracket notation access.
- Added coverage confirming generated types compile and retain the exact XML property names.

### Impact
`✅ Valid generated TypeScript for dotted and hyphenated XML names`
`✅ Preserved XML property names`
`✅ Reliable bracket-notation access to generated fields`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
