### PR TITLE
docs(ts-xsd): rewrite README for npm end-users, generalize docs

### DIFF
--- a/packages/ts-xsd/README.md
+++ b/packages/ts-xsd/README.md
@@ -194,9 +194,9 @@ import { parseXml, buildXml } from '@abapify/ts-xsd';
 
 Parse an XML string into a typed object using a schema definition.
 
-#### `buildXml<T>(schema, data: T): string`
+#### `buildXml<T>(schema, data: T, options?: XmlBuildOptions): string`
 
-Build an XML string from a typed object using a schema definition.
+Build an XML string from a typed object using a schema definition. Defaults to `xmlDecl: true` (includes `<?xml ...?>` declaration); pass `{ xmlDecl: false }` for bare output.
 
 ### Codegen Module
 

--- a/packages/ts-xsd/README.md
+++ b/packages/ts-xsd/README.md
@@ -83,9 +83,9 @@ import { parseXml, buildXml } from '@abapify/ts-xsd';
 
 const xml = `<person><name>John</name><age>30</age></person>`;
 const data = parseXml(personSchema, xml);
-// => { name: 'John', age: 30 }
+// => { person: { name: 'John', age: 30 } }
 
-const rebuilt = buildXml(personSchema, data);
+const rebuilt = buildXml(personSchema, data, { xmlDecl: false });
 // => <person><name>John</name><age>30</age></person>
 ```
 
@@ -211,7 +211,7 @@ Generate a TypeScript `as const` schema literal from XSD content — for use wit
 ```typescript
 const code = generateSchemaLiteral(xsdContent, {
   name: 'PersonSchema',
-  features: { $xmlns: true, $imports: true, $filename: true },
+  features: { $xmlns: true, $filename: true },
   exclude: ['annotation'],
 });
 // export const PersonSchema = { ... } as const;

--- a/packages/ts-xsd/README.md
+++ b/packages/ts-xsd/README.md
@@ -1,7 +1,7 @@
 # ts-xsd
 
 [![npm version](https://img.shields.io/npm/v/@abapify/ts-xsd)](https://www.npmjs.com/package/@abapify/ts-xsd)
-[![license](https://img.shields.io/npm/l/@abapify/ts-xsd)](./LICENSE)
+[![license](https://img.shields.io/npm/l/@abapify/ts-xsd)](https://github.com/abapify/adt-cli/blob/main/LICENSE)
 
 **W3C XSD 1.1 parser, builder, and TypeScript type inference** — a 1:1 TypeScript representation of XML Schema Definition.
 
@@ -114,6 +114,7 @@ import {
   parseXsd,
   buildXsd,
   resolveImports,
+  loadSchema,
   type Schema,
 } from '@abapify/ts-xsd';
 ```
@@ -134,19 +135,25 @@ const xsd = buildXsd(schema, {
 });
 ```
 
-#### `resolveImports(schema, resolver): Schema`
+#### `resolveImports(schema, availableSchemas): Schema`
 
-Resolve and link imported schemas for cross-schema type resolution.
+Resolve and link imported schemas by matching `import.schemaLocation` to `$filename`. Returns a new schema with `$imports` populated.
 
 ```typescript
-const linked = resolveImports(schema, (location) =>
-  parseXsd(fs.readFileSync(location, 'utf-8')),
-);
+const base = { ...parseXsd(baseXsd), $filename: 'base.xsd' };
+const orders = { ...parseXsd(ordersXsd), $filename: 'orders.xsd' };
+
+const linked = resolveImports(orders, [base]);
+// linked.$imports = [base]
 ```
 
-#### `loadSchema(path): Promise<Schema>`
+#### `loadSchema(schemaPath: string, options?: LoaderOptions): Schema`
 
-Load and parse an XSD file from disk with automatic import resolution.
+Load and parse an XSD file from disk. Synchronous. Set `autoLink: true` to automatically resolve imports, or `autoResolve: true` to merge everything into one schema.
+
+```typescript
+const schema = loadSchema('/path/to/schema.xsd', { autoLink: true });
+```
 
 ### Infer Module
 
@@ -230,17 +237,16 @@ const { code } = generateInterfaces(schema, {
 
 ### CLI
 
-The package ships a CLI for batch code generation:
+The package ships a CLI for code generation:
 
 ```bash
-# Generate a schema literal
-npx ts-xsd codegen -i schema.xsd -o schema.ts
+# Config-based (recommended) — uses ts-xsd.config.ts in cwd
+npx ts-xsd codegen
 
-# With options
-npx ts-xsd codegen -i schema.xsd -o schema.ts \
-  --name mySchema \
-  --features '$xmlns,$imports,$filename' \
-  --exclude annotation
+# Single-file mode
+npx ts-xsd codegen person.xsd
+npx ts-xsd codegen person.xsd ./generated/person-schema.ts
+npx ts-xsd codegen person.xsd --name=PersonSchema
 ```
 
 ### Config-Based Generation
@@ -255,14 +261,20 @@ import {
 } from '@abapify/ts-xsd/generators';
 
 export default defineConfig({
-  schemas: [
-    { name: 'base', xsd: 'schemas/base.xsd' },
-    { name: 'orders', xsd: 'schemas/orders.xsd', imports: ['base'] },
-  ],
-  generators: [
-    rawSchema({ outputDir: 'src/generated/schemas' }),
-    interfaces({ outputDir: 'src/generated/types', flatten: true }),
-  ],
+  sources: {
+    base: {
+      xsdDir: 'schemas',
+      outputDir: 'src/generated',
+      schemas: ['base'],
+    },
+    orders: {
+      xsdDir: 'schemas',
+      outputDir: 'src/generated',
+      schemas: ['orders'],
+      autoLink: true,
+    },
+  },
+  generators: [rawSchema(), interfaces({ flatten: true })],
 });
 ```
 
@@ -298,13 +310,10 @@ interface Schema {
 Link schemas via `$imports` to resolve types across schema boundaries:
 
 ```typescript
-const base = parseXsd(baseXsd);
-const orders = parseXsd(ordersXsd);
+const base = { ...parseXsd(baseXsd), $filename: 'base.xsd' };
+const orders = { ...parseXsd(ordersXsd), $filename: 'orders.xsd' };
 
-const linked = {
-  ...orders,
-  $imports: [base],
-};
+const linked = resolveImports(orders, [base]);
 
 // InferSchema can now resolve types from `base`
 type OrderData = InferSchema<typeof linked>;
@@ -314,7 +323,7 @@ type OrderData = InferSchema<typeof linked>;
 
 1. **Pure W3C XSD 1.1** — types match the official [XMLSchema.xsd](https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd) exactly; no invented properties.
 2. **Type-safe** — full TypeScript support with compile-time inference.
-3. **Minimal dependencies** — only `@xmldom/xmldom` at runtime.
+3. **Minimal dependencies** — `@xmldom/xmldom` for DOM parsing, `ts-morph` and `zod` for codegen.
 4. **Tree-shakeable** — import only what you need.
 5. **Round-trip verified** — tested against the official W3C XMLSchema.xsd.
 
@@ -322,8 +331,8 @@ type OrderData = InferSchema<typeof linked>;
 
 - [W3C XML Schema 1.1 Part 1: Structures](https://www.w3.org/TR/xmlschema11-1/)
 - [XMLSchema.xsd](https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd)
-- [Codegen Guide](./docs/codegen.md)
+- [Codegen Guide](https://github.com/abapify/adt-cli/tree/main/packages/ts-xsd/docs/codegen.md)
 
 ## License
 
-MIT
+[MIT](https://github.com/abapify/adt-cli/blob/main/LICENSE)

--- a/packages/ts-xsd/README.md
+++ b/packages/ts-xsd/README.md
@@ -1,36 +1,31 @@
 # ts-xsd
 
-[![version](https://img.shields.io/github/package-json/v/abapify/adt-cli?filename=packages/ts-xsd/package.json)](https://github.com/abapify/adt-cli/pkgs/npm/%40abapify%2Fts-xsd)
+[![npm version](https://img.shields.io/npm/v/@abapify/ts-xsd)](https://www.npmjs.com/package/@abapify/ts-xsd)
+[![license](https://img.shields.io/npm/l/@abapify/ts-xsd)](./LICENSE)
 
-**Core XSD parser, builder, and type inference** with **1:1 TypeScript representation** of W3C XML Schema Definition (XSD) 1.1.
+**W3C XSD 1.1 parser, builder, and TypeScript type inference** — a 1:1 TypeScript representation of XML Schema Definition.
 
-## Overview
+## Why
 
-`ts-xsd` is a comprehensive TypeScript library for working with W3C XSD schemas. It provides:
+Working with XSD schemas in TypeScript usually means hand-maintaining types that drift from the source of truth. `ts-xsd` closes that gap:
 
-| Module      | Purpose                                                             |
-| ----------- | ------------------------------------------------------------------- |
-| **xsd**     | Parse XSD files into typed `Schema` objects, build XSD from objects |
-| **infer**   | Compile-time TypeScript type inference from schema literals         |
-| **xml**     | Parse/build XML documents using schema definitions                  |
-| **codegen** | Generate TypeScript schema literals from XSD files                  |
-
-### Key Features
-
-- **Pure W3C XSD 1.1** - Types match the official [XMLSchema.xsd](https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd) exactly
-- **Full roundtrip** - `XSD → Schema → XSD` with semantic preservation
-- **Type inference** - `InferSchema<T>` extracts TypeScript types from schema literals
-- **Shared types** - Cross-schema type resolution via `$imports`
-- **Tree-shakeable** - Only import what you need
-- **Zero runtime dependencies** - Only `@xmldom/xmldom` for DOM parsing
+- **Parse** any W3C XSD 1.1 schema into a typed `Schema` object — no invented properties, no shortcuts.
+- **Infer** TypeScript types at compile time from schema literals via `InferSchema<T>`.
+- **Generate** TypeScript interfaces at build time when schemas are too complex for compile-time inference.
+- **Round-trip** `XSD → Schema → XSD` with semantic preservation.
+- **Parse/build XML** documents against a schema definition.
 
 ## Installation
 
 ```bash
 npm install @abapify/ts-xsd
 # or
+pnpm add @abapify/ts-xsd
+# or
 bun add @abapify/ts-xsd
 ```
+
+> **Runtime dependency:** `@xmldom/xmldom` (DOM parsing). `ts-morph` and `zod` are required for codegen features.
 
 ## Quick Start
 
@@ -61,7 +56,6 @@ const xsd = buildXsd(schema, { pretty: true });
 ```typescript
 import type { InferSchema } from '@abapify/ts-xsd';
 
-// Define schema as const literal
 const personSchema = {
   element: [{ name: 'person', type: 'PersonType' }],
   complexType: [
@@ -77,22 +71,38 @@ const personSchema = {
   ],
 } as const;
 
-// Infer TypeScript type at compile time
+// Infer TypeScript type at compile time — no runtime cost
 type Person = InferSchema<typeof personSchema>;
-// Result: { name: string; age?: number }
+// => { name: string; age?: number }
 ```
 
-### Parse XML with Schema
+### Parse and Build XML with a Schema
 
 ```typescript
 import { parseXml, buildXml } from '@abapify/ts-xsd';
 
 const xml = `<person><name>John</name><age>30</age></person>`;
 const data = parseXml(personSchema, xml);
-// data: { name: 'John', age: 30 }
+// => { name: 'John', age: 30 }
 
 const rebuilt = buildXml(personSchema, data);
-// rebuilt: <person><name>John</name><age>30</age></person>
+// => <person><name>John</name><age>30</age></person>
+```
+
+### Generate TypeScript Interfaces from XSD
+
+```typescript
+import { parseXsd, generateInterfaces } from '@abapify/ts-xsd';
+
+const schema = parseXsd(xsdContent);
+const { code } = generateInterfaces(schema, {
+  flatten: true, // Inline all nested types into one
+  addJsDoc: true, // Add JSDoc comments
+  rootTypeName: 'MySchema',
+});
+
+// code is a ready-to-write .ts file:
+// export type MySchema = { person: { name: string; age?: number } };
 ```
 
 ## API Reference
@@ -100,40 +110,43 @@ const rebuilt = buildXml(personSchema, data);
 ### XSD Module
 
 ```typescript
-import { parseXsd, buildXsd, type Schema } from '@abapify/ts-xsd';
+import {
+  parseXsd,
+  buildXsd,
+  resolveImports,
+  type Schema,
+} from '@abapify/ts-xsd';
 ```
 
 #### `parseXsd(xsd: string): Schema`
 
-Parse an XSD XML string into a typed Schema object.
-
-```typescript
-const schema = parseXsd(xsdString);
-console.log(schema.targetNamespace);
-console.log(schema.element?.[0].name);
-```
+Parse an XSD XML string into a typed `Schema` object.
 
 #### `buildXsd(schema: Schema, options?: BuildOptions): string`
 
-Build an XSD XML string from a Schema object.
+Build an XSD XML string from a `Schema` object.
 
 ```typescript
 const xsd = buildXsd(schema, {
-  prefix: 'xsd', // Namespace prefix (default: 'xs')
+  prefix: 'xs', // Namespace prefix (default: 'xs')
   pretty: true, // Pretty print (default: true)
-  indent: '  ', // Indentation (default: '  ')
+  indent: '  ', // Indentation string
 });
 ```
 
-#### `resolveImports(schema: Schema, resolver: (location: string) => Schema): Schema`
+#### `resolveImports(schema, resolver): Schema`
 
 Resolve and link imported schemas for cross-schema type resolution.
 
 ```typescript
-const linkedSchema = resolveImports(schema, (location) => {
-  return parseXsd(fs.readFileSync(location, 'utf-8'));
-});
+const linked = resolveImports(schema, (location) =>
+  parseXsd(fs.readFileSync(location, 'utf-8')),
+);
 ```
+
+#### `loadSchema(path): Promise<Schema>`
+
+Load and parse an XSD file from disk with automatic import resolution.
 
 ### Infer Module
 
@@ -143,15 +156,11 @@ import type { InferSchema, InferElement, SchemaLike } from '@abapify/ts-xsd';
 
 #### `InferSchema<T>`
 
-Infer TypeScript type from a schema literal. Returns union of all root element types.
+Infer a TypeScript type from a schema literal (`as const`). Returns a union of all root element types.
 
-```typescript
-type Data = InferSchema<typeof mySchema>;
-```
+#### `InferElement<T, Name>`
 
-#### `InferElement<T, ElementName>`
-
-Infer type for a specific element by name.
+Infer the type for a specific root element by name.
 
 ```typescript
 type Person = InferElement<typeof schema, 'person'>;
@@ -174,13 +183,13 @@ type Person = InferElement<typeof schema, 'person'>;
 import { parseXml, buildXml } from '@abapify/ts-xsd';
 ```
 
-#### `parseXml<T>(schema: SchemaLike, xml: string): T`
+#### `parseXml<T>(schema, xml: string): T`
 
-Parse XML string using schema definition.
+Parse an XML string into a typed object using a schema definition.
 
-#### `buildXml<T>(schema: SchemaLike, data: T): string`
+#### `buildXml<T>(schema, data: T): string`
 
-Build XML string from data using schema definition.
+Build an XML string from a typed object using a schema definition.
 
 ### Codegen Module
 
@@ -188,41 +197,83 @@ Build XML string from data using schema definition.
 import { generateSchemaLiteral, generateInterfaces } from '@abapify/ts-xsd';
 ```
 
-#### `generateSchemaLiteral(xsd: string, options?: GenerateOptions): string`
+#### `generateSchemaLiteral(xsd: string, options?): string`
 
-Generate TypeScript schema literal from XSD content.
+Generate a TypeScript `as const` schema literal from XSD content — for use with `InferSchema<T>`.
 
 ```typescript
 const code = generateSchemaLiteral(xsdContent, {
   name: 'PersonSchema',
-  features: { $xmlns: true, $imports: true },
+  features: { $xmlns: true, $imports: true, $filename: true },
   exclude: ['annotation'],
 });
-// export default { ... } as const;
+// export const PersonSchema = { ... } as const;
 ```
 
-#### `generateInterfaces(schema: Schema, options?: GenerateInterfacesOptions): GenerateInterfacesResult`
+#### `generateInterfaces(schema: Schema, options?): { code: string }`
 
-Generate TypeScript interfaces from parsed schema. Returns an object with `code` property containing the generated TypeScript code.
+Generate TypeScript interfaces from a parsed schema. Useful when schemas are too complex for compile-time `InferSchema<T>` (TypeScript TS2589 recursion limits).
 
 ```typescript
 const { code } = generateInterfaces(schema, {
   flatten: true, // Inline all nested types (default: false)
-  addJsDoc: true, // Add JSDoc comments
-  rootTypeName: 'MySchema', // Custom root type name
+  addJsDoc: true, // JSDoc comments
+  rootTypeName: 'MySchema',
+});
+```
+
+| Option         | Type      | Default | Description                      |
+| -------------- | --------- | ------- | -------------------------------- |
+| `flatten`      | `boolean` | `false` | Inline all nested types into one |
+| `addJsDoc`     | `boolean` | `false` | Add JSDoc comments               |
+| `rootTypeName` | `string`  | auto    | Custom name for the root type    |
+
+### CLI
+
+The package ships a CLI for batch code generation:
+
+```bash
+# Generate a schema literal
+npx ts-xsd codegen -i schema.xsd -o schema.ts
+
+# With options
+npx ts-xsd codegen -i schema.xsd -o schema.ts \
+  --name mySchema \
+  --features '$xmlns,$imports,$filename' \
+  --exclude annotation
+```
+
+### Config-Based Generation
+
+For multi-schema projects, use the composable generator system:
+
+```typescript
+import {
+  defineConfig,
+  rawSchema,
+  interfaces,
+} from '@abapify/ts-xsd/generators';
+
+export default defineConfig({
+  schemas: [
+    { name: 'base', xsd: 'schemas/base.xsd' },
+    { name: 'orders', xsd: 'schemas/orders.xsd', imports: ['base'] },
+  ],
+  generators: [
+    rawSchema({ outputDir: 'src/generated/schemas' }),
+    interfaces({ outputDir: 'src/generated/types', flatten: true }),
+  ],
 });
 ```
 
 ## Schema Structure
 
-The `Schema` type is a 1:1 TypeScript representation of W3C XSD:
+The `Schema` type is a 1:1 TypeScript representation of W3C XSD. Non-W3C extension properties are prefixed with `$`:
 
 ```typescript
 interface Schema {
-  // Namespace
   targetNamespace?: string;
   elementFormDefault?: 'qualified' | 'unqualified';
-  attributeFormDefault?: 'qualified' | 'unqualified';
 
   // Composition
   import?: Import[];
@@ -236,170 +287,42 @@ interface Schema {
   attributeGroup?: NamedAttributeGroup[];
 
   // Extensions (non-W3C, prefixed with $)
-  $xmlns?: { [prefix: string]: string };
-  $imports?: Schema[]; // Resolved imported schemas
-  $filename?: string; // Source filename
+  $xmlns?: { [prefix: string]: string }; // Namespace prefix mappings
+  $imports?: Schema[]; // Linked imported schemas
+  $filename?: string; // Source filename (for round-trip)
 }
 ```
 
 ### Cross-Schema Type Resolution
 
-Link schemas together for cross-schema type resolution:
+Link schemas via `$imports` to resolve types across schema boundaries:
 
 ```typescript
-const adtcore = parseXsd(adtcoreXsd);
-const classes = parseXsd(classesXsd);
+const base = parseXsd(baseXsd);
+const orders = parseXsd(ordersXsd);
 
-// Link schemas via $imports
-const linkedClasses = {
-  ...classes,
-  $imports: [adtcore],
+const linked = {
+  ...orders,
+  $imports: [base],
 };
 
-// Now InferSchema can resolve types from adtcore
-type AbapClass = InferSchema<typeof linkedClasses>;
+// InferSchema can now resolve types from `base`
+type OrderData = InferSchema<typeof linked>;
 ```
-
-## Type Inference Deep Dive
-
-### How It Works
-
-The type inference system uses TypeScript's conditional types to:
-
-1. **Find root elements** - Extract element declarations from schema
-2. **Resolve type references** - Look up `complexType` and `simpleType` by name
-3. **Handle inheritance** - Process `complexContent/extension` for type inheritance
-4. **Map XSD to TS** - Convert XSD types to TypeScript equivalents
-5. **Handle optionality** - `minOccurs="0"` → optional property
-6. **Handle arrays** - `maxOccurs="unbounded"` → array type
-
-### Example: Complex Schema
-
-```typescript
-const schema = {
-  $imports: [baseSchema],
-  element: [{ name: 'order', type: 'OrderType' }],
-  complexType: [
-    {
-      name: 'OrderType',
-      complexContent: {
-        extension: {
-          base: 'base:BaseEntity', // Inherits from imported schema
-          sequence: {
-            element: [
-              { name: 'items', type: 'ItemType', maxOccurs: 'unbounded' },
-              { name: 'total', type: 'xs:decimal' },
-            ],
-          },
-        },
-      },
-    },
-    {
-      name: 'ItemType',
-      sequence: {
-        element: [
-          { name: 'sku', type: 'xs:string' },
-          { name: 'quantity', type: 'xs:int' },
-        ],
-      },
-    },
-  ],
-} as const;
-
-type Order = InferSchema<typeof schema>;
-// Result:
-// {
-//   ...BaseEntity,  // Inherited properties
-//   items: { sku: string; quantity: number }[];
-//   total: number;
-// }
-```
-
-## Architecture
-
-```
-@abapify/ts-xsd
-├── src/
-│   ├── index.ts           # Main exports
-│   ├── xsd/               # XSD parsing, building, resolution
-│   │   ├── types.ts       # W3C 1:1 type definitions
-│   │   ├── parse.ts       # XSD XML → Schema parser
-│   │   ├── build.ts       # Schema → XSD XML builder
-│   │   ├── resolve.ts     # Schema resolver (merges imports, expands inheritance)
-│   │   ├── traverser.ts   # OO schema traversal with W3C types
-│   │   ├── loader.ts      # XSD file loading with import resolution
-│   │   ├── schema-like.ts # Runtime schema type guards
-│   │   └── helpers.ts     # Utility functions
-│   ├── infer/             # Compile-time type inference
-│   │   └── types.ts       # InferSchema<T>, InferElement<T>
-│   ├── xml/               # XML parsing/building with schemas
-│   │   ├── parse.ts       # XML → Object parser
-│   │   ├── build.ts       # Object → XML builder
-│   │   ├── typed.ts       # Typed schema wrapper
-│   │   └── dom-utils.ts   # DOM manipulation utilities
-│   ├── walker/            # Schema traversal utilities
-│   │   └── index.ts       # walkElements, walkComplexTypes, findSubstitutes
-│   ├── codegen/           # Code generation
-│   │   ├── generate.ts    # Schema literal generator
-│   │   ├── interface-generator.ts  # Interface generator API
-│   │   ├── ts-morph.ts    # TypeScript AST manipulation
-│   │   ├── runner.ts      # Config-based codegen runner
-│   │   └── cli.ts         # CLI interface
-│   └── generators/        # Generator plugins
-│       ├── raw-schema.ts  # Schema literal generator
-│       ├── interfaces.ts  # TypeScript interfaces generator
-│       ├── typed-schemas.ts # Typed schema exports
-│       └── index-barrel.ts # Index file generator
-```
-
-### Key Components
-
-| Component     | Purpose                                                                            |
-| ------------- | ---------------------------------------------------------------------------------- |
-| **Resolver**  | Merges `$imports`, expands `complexContent/extension`, handles `substitutionGroup` |
-| **Traverser** | OO traversal with real W3C XSD types (SchemaTraverser class)                       |
-| **Walker**    | Functional iteration over schema elements, types, groups                           |
-| **Loader**    | File-based XSD loading with automatic import resolution                            |
 
 ## Design Principles
 
-1. **Pure W3C XSD** - No invented properties or conveniences
-2. **Type safety** - Full TypeScript support with inference
-3. **Minimal dependencies** - Only `@xmldom/xmldom`
-4. **Tree-shakeable** - Import only what you need
-5. **Tested against W3C** - Verified with official XMLSchema.xsd
-
-## Testing
-
-```bash
-# Run all tests
-npx nx test ts-xsd
-
-# Run with coverage
-npx nx test:coverage ts-xsd
-```
-
-Tests include:
-
-- Unit tests for parser, builder, and inference
-- Integration tests with real XSD files
-- W3C XMLSchema.xsd roundtrip verification
-
-## Related Packages
-
-- **[@abapify/adt-schemas](../adt-schemas)** - SAP ADT schemas using ts-xsd
-- **[@abapify/adt-contracts](../adt-contracts)** - REST contracts for SAP ADT APIs
-- **[@abapify/adt-plugin-abapgit](../adt-plugin-abapgit)** - abapGit plugin schemas
-
-## Documentation
-
-- **[Codegen Guide](./docs/codegen.md)** - Comprehensive code generation documentation
-- **[AGENTS.md](./AGENTS.md)** - AI agent guidelines
+1. **Pure W3C XSD 1.1** — types match the official [XMLSchema.xsd](https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd) exactly; no invented properties.
+2. **Type-safe** — full TypeScript support with compile-time inference.
+3. **Minimal dependencies** — only `@xmldom/xmldom` at runtime.
+4. **Tree-shakeable** — import only what you need.
+5. **Round-trip verified** — tested against the official W3C XMLSchema.xsd.
 
 ## References
 
 - [W3C XML Schema 1.1 Part 1: Structures](https://www.w3.org/TR/xmlschema11-1/)
 - [XMLSchema.xsd](https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd)
+- [Codegen Guide](./docs/codegen.md)
 
 ## License
 

--- a/packages/ts-xsd/docs/codegen.md
+++ b/packages/ts-xsd/docs/codegen.md
@@ -307,7 +307,7 @@ const result = await runCodegen(config, { rootDir: __dirname });
 
 The codegen module powers a typical schema generation pipeline:
 
-```
+```text
 XSD Files (.xsd)
     ↓ generateSchemaLiteral
 Schema Literals (as const)

--- a/packages/ts-xsd/docs/codegen.md
+++ b/packages/ts-xsd/docs/codegen.md
@@ -256,16 +256,16 @@ import {
 
 export default defineConfig({
   schemas: [
-    { name: 'adtcore', xsd: '.xsd/sap/adtcore.xsd' },
-    { name: 'classes', xsd: '.xsd/sap/classes.xsd', imports: ['adtcore'] },
+    { name: 'base', xsd: 'schemas/base.xsd' },
+    { name: 'orders', xsd: 'schemas/orders.xsd', imports: ['base'] },
   ],
   generators: [
     rawSchema({
-      outputDir: 'src/schemas/generated/schemas',
+      outputDir: 'src/generated/schemas',
       features: { $xmlns: true, $imports: true, $filename: true },
     }),
     interfaces({
-      outputDir: 'src/schemas/generated/types',
+      outputDir: 'src/generated/types',
       flatten: true, // Inline all types
     }),
   ],
@@ -300,18 +300,18 @@ import { runGenerators } from '@abapify/ts-xsd/generators';
 await runGenerators(config);
 ```
 
-## Usage in adt-schemas
+## Usage Example
 
-The codegen module powers the schema generation pipeline:
+The codegen module powers a typical schema generation pipeline:
 
 ```
-XSD Files (.xsd/model/)
+XSD Files (.xsd)
     ↓ generateSchemaLiteral
 Schema Literals (as const)
     ↓ generateInterfaces
-TypeScript Interfaces (204 types)
+TypeScript Interfaces
     ↓ typed() wrapper
-Typed Schemas (parse/build)
+Typed Schemas (parse/build XML)
 ```
 
 ### Generation Script Example
@@ -325,19 +325,19 @@ import {
 import { readFileSync, writeFileSync } from 'fs';
 
 // 1. Generate schema literal
-const xsd = readFileSync('classes.xsd', 'utf-8');
+const xsd = readFileSync('orders.xsd', 'utf-8');
 const schemaCode = generateSchemaLiteral(xsd, {
-  name: 'classes',
+  name: 'orders',
   features: { $xmlns: true, $imports: true, $filename: true },
   exclude: ['annotation'],
   importResolver: (loc) => `./${loc.replace('.xsd', '')}`,
 });
-writeFileSync('schemas/classes.ts', schemaCode);
+writeFileSync('schemas/orders.ts', schemaCode);
 
 // 2. Generate interfaces
 const schema = parseXsd(xsd);
-const interfaces = generateInterfaces(schema, { generateAllTypes: true });
-writeFileSync('types/classes.ts', interfaces);
+const { code } = generateInterfaces(schema, { flatten: true });
+writeFileSync('types/orders.ts', code);
 ```
 
 ## Best Practices
@@ -385,10 +385,10 @@ Ensure generated schemas work correctly:
 
 ```typescript
 import { parseXml, buildXml } from '@abapify/ts-xsd';
-import { classes } from './generated/classes';
+import { orders } from './generated/orders';
 
-const data = parseXml(classes, xmlString);
-const rebuilt = buildXml(classes, data);
+const data = parseXml(orders, xmlString);
+const rebuilt = buildXml(orders, data);
 // Verify rebuilt matches original structure
 ```
 
@@ -410,5 +410,4 @@ npx ts-xsd codegen -i schema.xsd -o schema.ts \
 ## Reference
 
 - [ts-xsd README](../README.md)
-- [ts-xsd AGENTS.md](../AGENTS.md)
-- [adt-schemas](../../adt-schemas/README.md) - Real-world usage
+- [W3C XML Schema 1.1](https://www.w3.org/TR/xmlschema11-1/)

--- a/packages/ts-xsd/docs/codegen.md
+++ b/packages/ts-xsd/docs/codegen.md
@@ -300,7 +300,7 @@ npx nx codegen my-package
 
 # Programmatically
 import { runCodegen } from '@abapify/ts-xsd/generators';
-const result = await runCodegen(config, { rootDir: __dirname });
+const result = await runCodegen(config, { rootDir: process.cwd() });
 ```
 
 ## Usage Example
@@ -387,7 +387,7 @@ Ensure generated schemas work correctly:
 
 ```typescript
 import { parseXml, buildXml } from '@abapify/ts-xsd';
-import orders from './generated/schemas/orders';
+import orders from './src/generated/orders';
 
 const data = parseXml(orders, xmlString);
 const rebuilt = buildXml(orders, data);

--- a/packages/ts-xsd/docs/codegen.md
+++ b/packages/ts-xsd/docs/codegen.md
@@ -61,7 +61,7 @@ const xsd = `
 
 const code = generateSchemaLiteral(xsd, {
   name: 'person',
-  features: { $xmlns: true, $imports: true, $filename: true },
+  features: { $xmlns: true, $filename: true },
   exclude: ['annotation'],
 });
 ```
@@ -331,9 +331,8 @@ import { readFileSync, writeFileSync } from 'fs';
 const xsd = readFileSync('orders.xsd', 'utf-8');
 const schemaCode = generateSchemaLiteral(xsd, {
   name: 'orders',
-  features: { $xmlns: true, $imports: true, $filename: true },
+  features: { $xmlns: true, $filename: true },
   exclude: ['annotation'],
-  importResolver: (loc) => `./${loc.replace('.xsd', '')}`,
 });
 writeFileSync('schemas/orders.ts', schemaCode);
 
@@ -388,7 +387,7 @@ Ensure generated schemas work correctly:
 
 ```typescript
 import { parseXml, buildXml } from '@abapify/ts-xsd';
-import { orders } from './generated/orders';
+import orders from './generated/schemas/orders';
 
 const data = parseXml(orders, xmlString);
 const rebuilt = buildXml(orders, data);

--- a/packages/ts-xsd/docs/codegen.md
+++ b/packages/ts-xsd/docs/codegen.md
@@ -255,19 +255,22 @@ import {
 } from '@abapify/ts-xsd/generators';
 
 export default defineConfig({
-  schemas: [
-    { name: 'base', xsd: 'schemas/base.xsd' },
-    { name: 'orders', xsd: 'schemas/orders.xsd', imports: ['base'] },
-  ],
+  sources: {
+    base: {
+      xsdDir: 'schemas',
+      outputDir: 'src/generated',
+      schemas: ['base'],
+    },
+    orders: {
+      xsdDir: 'schemas',
+      outputDir: 'src/generated',
+      schemas: ['orders'],
+      autoLink: true,
+    },
+  },
   generators: [
-    rawSchema({
-      outputDir: 'src/generated/schemas',
-      features: { $xmlns: true, $imports: true, $filename: true },
-    }),
-    interfaces({
-      outputDir: 'src/generated/types',
-      flatten: true, // Inline all types
-    }),
+    rawSchema({ $xmlns: true, $imports: true, $filename: true }),
+    interfaces({ flatten: true }),
   ],
 });
 ```
@@ -296,8 +299,8 @@ interface Generator {
 npx nx codegen my-package
 
 # Programmatically
-import { runGenerators } from '@abapify/ts-xsd/generators';
-await runGenerators(config);
+import { runCodegen } from '@abapify/ts-xsd/generators';
+const result = await runCodegen(config, { rootDir: __dirname });
 ```
 
 ## Usage Example
@@ -376,7 +379,7 @@ Avoid TypeScript recursion limits:
 
 ```typescript
 // For schemas with 50+ types, generate interfaces
-const interfaces = generateInterfaces(schema, { generateAllTypes: true });
+const { code } = generateInterfaces(schema, { flatten: true });
 ```
 
 ### 5. Verify with Round-Trip Tests
@@ -397,14 +400,13 @@ const rebuilt = buildXml(orders, data);
 The codegen module includes a CLI for batch generation:
 
 ```bash
-# Generate schema literal
-npx ts-xsd codegen -i schema.xsd -o schema.ts
+# Config-based (recommended) — uses ts-xsd.config.ts in cwd
+npx ts-xsd codegen
 
-# With options
-npx ts-xsd codegen -i schema.xsd -o schema.ts \
-  --name mySchema \
-  --features '$xmlns,$imports,$filename' \
-  --exclude annotation
+# Single-file mode
+npx ts-xsd codegen person.xsd
+npx ts-xsd codegen person.xsd ./generated/person-schema.ts
+npx ts-xsd codegen person.xsd --name=PersonSchema
 ```
 
 ## Reference

--- a/packages/ts-xsd/package.json
+++ b/packages/ts-xsd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abapify/ts-xsd",
   "version": "0.4.1",
-  "description": "Core XSD parser and builder - W3C XMLSchema 1:1 TypeScript representation",
+  "description": "W3C XSD 1.1 parser, builder, and TypeScript type inference",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## **User description**
## Summary
- Rewrite `packages/ts-xsd/README.md` to target npm consumers instead of repo contributors: remove internal architecture, file tree, testing commands, and AGENTS.md links; add a "Why" section; use generic examples (person/order) instead of SAP ADT-specific ones; replace GitHub Packages badge with npm badge
- Update `packages/ts-xsd/docs/codegen.md`: replace SAP-specific examples (adtcore, classes, AbapClass) with generic ones; rename "Usage in adt-schemas" → "Usage Example"; remove internal references
- Update `package.json` description to be more general

The package is useful beyond the abapify ecosystem — the docs should reflect that.

#### Test plan
- [ ] CI passes (docs-only change, no code affected)
- [ ] README renders correctly on npm

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites `@abapify/ts-xsd` docs for npm end users and general XSD projects, replacing SAP ADT and repository-specific examples with generic person/order examples. The README, codegen guide, and package metadata now present the library as a standalone npm package and match its actual API.

- Adds npm, pnpm, and Bun install examples plus runtime and codegen dependency notes.
- Documents XML parsing, interface generation, CLI usage, config-based generation, import resolution, and API options.
- Corrects API examples to real signatures and behavior (`resolveImports`, `loadSchema`, `runCodegen`, `generateInterfaces`, CLI flags, `parseXml`/`buildXml`, `generateSchemaLiteral`), including ESM-safe paths and aligned generated-file imports.
- Removes internal architecture, testing instructions, contributor links, and related-package references.
- No runtime or API behavior changes; only Markdown and package metadata are updated.

<sup>Written for commit 2eee53b95a78543f53a8fedb788c886db6e77b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the package README with updated installation, quick-start, API reference, CLI, configuration, and schema guidance.
  * Added documentation for schema loading, cross-schema type resolution, and config-based code generation.
  * Updated code generation examples to use source-based configuration and revised programmatic and CLI workflows.
  * Added clearer guidance for XML parsing, building, and TypeScript interface generation.
* **Chores**
  * Updated the package description to clarify support for W3C XSD 1.1 parsing, building, and TypeScript type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Reframe ts-xsd documentation for standalone npm users and align examples with the current API

### What Changed
- README now presents ts-xsd as a general-purpose W3C XSD 1.1 package, with npm installation, license details, runtime dependencies, and generic person/order examples
- Documents XML parsing and building, TypeScript interface generation, schema imports, CLI usage, and config-based code generation using the current commands and options
- Codegen guide replaces SAP-specific examples and outdated API usage with generic schemas and working generation workflows
- Package metadata now describes the parser, builder, and TypeScript type inference capabilities more accurately

### Impact
`✅ Clearer npm installation and package usage`
`✅ Working code examples for schema parsing and code generation`
`✅ Usable documentation for non-SAP XSD projects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
