### PR TITLE
feat(abapgit): dual-format deserialization foundation (XML + AFF JSON)

### DIFF
--- a/packages/adt-plugin-abapgit/src/lib/deserializer.ts
+++ b/packages/adt-plugin-abapgit/src/lib/deserializer.ts
@@ -22,36 +22,13 @@ import { extractFunctionDescriptors } from './handlers/objects/fugr';
 /**
  * abapGit file naming convention:
  * - XML metadata: {name}.{type}.xml (e.g., zcl_myclass.clas.xml)
+ * - AFF JSON metadata: {name}.{type}.json (e.g., zfoo.bdef.json)
  * - Source code: {name}.{type}.abap (e.g., zcl_myclass.clas.abap)
  * - Source includes: {name}.{type}.{suffix}.abap (e.g., zcl_myclass.clas.testclasses.abap)
+ * - AFF source files: {name}.{type}.abdl, {name}.{type}.acds, {name}.{type}.asrvd
  */
 
-/**
- * Parse abapGit filename to extract object info
- */
-export function parseAbapGitFilename(filename: string): {
-  name: string;
-  type: string;
-  suffix?: string;
-  extension: string;
-} | null {
-  // Match patterns like: name.type.xml, name.type.suffix.abap, or
-  // name.type.<suffix>.abdl/.asrvd source files.
-  const match = filename.match(
-    /^([^.]+)\.([^.]+)(?:\.([^.]+))?\.(xml|abap|abdl|asrvd)$/,
-  );
-  if (!match) return null;
-
-  const [, name, type, suffixOrExt, extension] = match;
-
-  // If 4 parts, middle is suffix; if 3 parts, no suffix
-  return {
-    name: name.toUpperCase(),
-    type: type.toUpperCase(),
-    suffix: suffixOrExt && suffixOrExt !== extension ? suffixOrExt : undefined,
-    extension,
-  };
-}
+import { parseAbapGitFilename } from './filename-parser';
 
 /**
  * Group related files by object (name + type)
@@ -59,7 +36,10 @@ export function parseAbapGitFilename(filename: string): {
 interface ObjectFiles {
   name: string;
   type: string;
+  /** Legacy XML metadata file path (if present) */
   xmlFile?: string;
+  /** AFF JSON metadata file path (if present) */
+  jsonFile?: string;
   sourceFiles: Array<{ path: string; suffix?: string }>;
 }
 
@@ -96,8 +76,11 @@ export async function* deserialize(
     }
   }
 
-  // Find all XML files (these define the objects)
-  const xmlFiles = await fileTree.glob('**/*.xml');
+  // Find all metadata files (XML = legacy, JSON = AFF)
+  const [xmlFiles, jsonFiles] = await Promise.all([
+    fileTree.glob('**/*.xml'),
+    fileTree.glob('**/*.json'),
+  ]);
 
   // Filter to supported types and group by object
   const objectMap = new Map<string, ObjectFiles>();
@@ -105,6 +88,7 @@ export async function* deserialize(
     getSupportedTypes().map((t) => t.toLowerCase()),
   );
 
+  // Process XML metadata files (legacy abapGit format)
   for (const xmlPath of xmlFiles) {
     // Skip .abapgit.xml metadata file
     if (xmlPath.endsWith('.abapgit.xml')) continue;
@@ -137,13 +121,39 @@ export async function* deserialize(
     obj.xmlFile = xmlPath;
   }
 
-  // Find source files for each object (abap + new BDEF/SRVD extensions)
-  const [abapFiles, abdlFiles, asrvdFiles] = await Promise.all([
+  // Process JSON metadata files (AFF format)
+  for (const jsonPath of jsonFiles) {
+    const filename = jsonPath.slice(jsonPath.lastIndexOf('/') + 1);
+    const parsed = parseAbapGitFilename(filename);
+
+    if (!parsed) continue;
+    if (!supportedTypes.has(parsed.type.toLowerCase())) continue;
+
+    // JSON metadata files don't have suffixes
+    if (parsed.suffix) continue;
+
+    const key = `${parsed.name}:${parsed.type}`;
+
+    if (!objectMap.has(key)) {
+      objectMap.set(key, {
+        name: parsed.name,
+        type: parsed.type,
+        sourceFiles: [],
+      });
+    }
+
+    const obj = objectMap.get(key)!;
+    obj.jsonFile = jsonPath;
+  }
+
+  // Find source files for each object (abap + AFF source extensions)
+  const [abapFiles, abdlFiles, acdsFiles, asrvdFiles] = await Promise.all([
     fileTree.glob('**/*.abap'),
     fileTree.glob('**/*.abdl'),
+    fileTree.glob('**/*.acds'),
     fileTree.glob('**/*.asrvd'),
   ]);
-  const sourceFiles = [...abapFiles, ...abdlFiles, ...asrvdFiles];
+  const sourceFiles = [...abapFiles, ...abdlFiles, ...acdsFiles, ...asrvdFiles];
 
   for (const sourcePath of sourceFiles) {
     const filename = sourcePath.slice(sourcePath.lastIndexOf('/') + 1);
@@ -161,17 +171,40 @@ export async function* deserialize(
 
   // Process each object and yield
   for (const [, objFiles] of objectMap) {
-    if (!objFiles.xmlFile) continue;
+    // Must have at least one metadata file (XML or JSON)
+    if (!objFiles.xmlFile && !objFiles.jsonFile) continue;
 
     const handler = getHandler(objFiles.type);
     if (!handler) continue;
 
     try {
-      // Read and parse XML using handler's schema
-      const xmlContent = await fileTree.read(objFiles.xmlFile);
-      const parsed = handler.schema.parse(xmlContent);
-      // Schema parses to { abapGit: { abap: { values: ... } } }
-      const values = (parsed as any)?.abapGit?.abap?.values ?? {};
+      let values: Record<string, unknown>;
+      let isAffJson = false;
+
+      if (objFiles.jsonFile) {
+        // AFF JSON metadata file
+        const jsonContent = await fileTree.read(objFiles.jsonFile);
+        const jsonData = JSON.parse(jsonContent) as Record<string, unknown>;
+        isAffJson = true;
+
+        // If handler has fromAffJson, use it; otherwise fall back to
+        // extracting values from the JSON body
+        if (handler.fromAffJson) {
+          const affPayload = handler.fromAffJson(jsonData);
+          values = affPayload as Record<string, unknown>;
+        } else {
+          // No fromAffJson — use the JSON body directly as values
+          values = jsonData;
+        }
+      } else if (objFiles.xmlFile) {
+        // Legacy XML metadata file
+        const xmlContent = await fileTree.read(objFiles.xmlFile);
+        const parsed = handler.schema.parse(xmlContent);
+        // Schema parses to { abapGit: { abap: { values: ... } } }
+        values = (parsed as any)?.abapGit?.abap?.values ?? {};
+      } else {
+        continue;
+      }
 
       // Read source files, mapping suffixes using handler's suffixToSourceKey
       const sources: Record<string, string> = {};
@@ -185,13 +218,21 @@ export async function* deserialize(
       }
 
       // Get payload from handler (pure data mapping) or build default
-      const payload: {
+      let payload: {
         name: string;
         description?: string;
         [key: string]: unknown;
-      } = handler.fromAbapGit
-        ? handler.fromAbapGit(values)
-        : { name: objFiles.name };
+      };
+
+      if (isAffJson && handler.fromAffJson) {
+        // For AFF JSON, fromAffJson was already called above and returned
+        // the full payload (not just values)
+        payload = values as { name: string; description?: string };
+      } else if (handler.fromAbapGit) {
+        payload = handler.fromAbapGit(values);
+      } else {
+        payload = { name: objFiles.name };
+      }
 
       // Use filename as fallback if name not in XML (e.g., DEVC)
       const objectName = payload.name || objFiles.name;
@@ -230,7 +271,8 @@ export async function* deserialize(
       // This metadata is always computed so the export command can auto-detect
       // the root package from SAP and resolve packages later if needed.
       if (hasAbapGitXml) {
-        const sourceDir = objFiles.xmlFile.split('/').slice(0, -1).join('/');
+        const metadataFile = objFiles.xmlFile ?? objFiles.jsonFile ?? '';
+        const sourceDir = metadataFile.split('/').slice(0, -1).join('/');
         const relDir = sourceDir.startsWith(startDir)
           ? sourceDir.slice(startDir.length).replace(/^\/+/, '')
           : sourceDir;

--- a/packages/adt-plugin-abapgit/src/lib/deserializer.ts
+++ b/packages/adt-plugin-abapgit/src/lib/deserializer.ts
@@ -30,6 +30,10 @@ import { extractFunctionDescriptors } from './handlers/objects/fugr';
 
 import { parseAbapGitFilename } from './filename-parser';
 
+// Re-export for backward compatibility — format-plugin and other modules
+// import parseAbapGitFilename from deserializer.
+export { parseAbapGitFilename };
+
 /**
  * Group related files by object (name + type)
  */
@@ -184,7 +188,16 @@ export async function* deserialize(
       if (objFiles.jsonFile) {
         // AFF JSON metadata file
         const jsonContent = await fileTree.read(objFiles.jsonFile);
-        const jsonData = JSON.parse(jsonContent) as Record<string, unknown>;
+        let jsonData: Record<string, unknown>;
+        try {
+          jsonData = JSON.parse(jsonContent) as Record<string, unknown>;
+        } catch (parseError) {
+          console.error(
+            `Failed to parse AFF JSON ${objFiles.jsonFile}:`,
+            parseError,
+          );
+          continue;
+        }
         isAffJson = true;
 
         // If handler has fromAffJson, use it; otherwise fall back to
@@ -228,6 +241,10 @@ export async function* deserialize(
         // For AFF JSON, fromAffJson was already called above and returned
         // the full payload (not just values)
         payload = values as { name: string; description?: string };
+      } else if (isAffJson && !handler.fromAffJson) {
+        // No fromAffJson — use filename-derived name; JSON body is not
+        // compatible with fromAbapGit (which expects XML SKEY envelope)
+        payload = { name: objFiles.name };
       } else if (handler.fromAbapGit) {
         payload = handler.fromAbapGit(values);
       } else {

--- a/packages/adt-plugin-abapgit/src/lib/deserializer.ts
+++ b/packages/adt-plugin-abapgit/src/lib/deserializer.ts
@@ -48,6 +48,200 @@ interface ObjectFiles {
 }
 
 /**
+ * Resolve folder logic and start dir from .abapgit.xml
+ */
+async function resolveFolderConfig(fileTree: FileTree): Promise<{
+  folderLogic: import('./folder-logic').FolderLogic;
+  startDir: string;
+  hasAbapGitXml: boolean;
+}> {
+  let folderLogic: import('./folder-logic').FolderLogic = 'prefix';
+  let startDir = '';
+  const hasAbapGitXml = await fileTree.exists('.abapgit.xml');
+  if (hasAbapGitXml) {
+    try {
+      const xml = await fileTree.read('.abapgit.xml');
+      const meta = parseAbapGitMetadata(xml);
+      folderLogic = meta.folderLogic;
+      startDir = stripSlashes(meta.startingFolder);
+    } catch {
+      // Fall through to defaults if XML parsing fails
+    }
+  }
+  return { folderLogic, startDir, hasAbapGitXml };
+}
+
+/**
+ * Parse a metadata file path into an object key and register it in the map.
+ */
+function registerMetadataFile(
+  path: string,
+  supportedTypes: Set<string>,
+  objectMap: Map<string, ObjectFiles>,
+  field: 'xmlFile' | 'jsonFile',
+): void {
+  const filename = path.slice(path.lastIndexOf('/') + 1);
+  const parsed = parseAbapGitFilename(filename);
+  if (!parsed) return;
+  if (!supportedTypes.has(parsed.type.toLowerCase())) return;
+  if (parsed.suffix) return;
+
+  const key = `${parsed.name}:${parsed.type}`;
+  if (!objectMap.has(key)) {
+    objectMap.set(key, {
+      name: parsed.name,
+      type: parsed.type,
+      sourceFiles: [],
+    });
+  }
+  objectMap.get(key)![field] = path;
+}
+
+/**
+ * Collect all source files and attach them to their objects in the map.
+ */
+async function collectSourceFiles(
+  fileTree: FileTree,
+  objectMap: Map<string, ObjectFiles>,
+): Promise<void> {
+  const [abapFiles, abdlFiles, acdsFiles, asrvdFiles] = await Promise.all([
+    fileTree.glob('**/*.abap'),
+    fileTree.glob('**/*.abdl'),
+    fileTree.glob('**/*.acds'),
+    fileTree.glob('**/*.asrvd'),
+  ]);
+  for (const sourcePath of [
+    ...abapFiles,
+    ...abdlFiles,
+    ...acdsFiles,
+    ...asrvdFiles,
+  ]) {
+    const filename = sourcePath.slice(sourcePath.lastIndexOf('/') + 1);
+    const parsed = parseAbapGitFilename(filename);
+    if (!parsed) continue;
+    const obj = objectMap.get(`${parsed.name}:${parsed.type}`);
+    if (obj) obj.sourceFiles.push({ path: sourcePath, suffix: parsed.suffix });
+  }
+}
+
+/**
+ * Parse metadata (XML or JSON) and return values + isAffJson flag.
+ */
+async function parseMetadata(
+  fileTree: FileTree,
+  objFiles: ObjectFiles,
+  handler: ReturnType<typeof getHandler>,
+): Promise<{ values: Record<string, unknown>; isAffJson: boolean } | null> {
+  if (objFiles.jsonFile) {
+    const jsonContent = await fileTree.read(objFiles.jsonFile);
+    let jsonData: Record<string, unknown>;
+    try {
+      jsonData = JSON.parse(jsonContent) as Record<string, unknown>;
+    } catch (parseError) {
+      console.error(
+        `Failed to parse AFF JSON ${objFiles.jsonFile}:`,
+        parseError,
+      );
+      return null;
+    }
+    const values = handler?.fromAffJson
+      ? (handler.fromAffJson(jsonData) as Record<string, unknown>)
+      : jsonData;
+    return { values, isAffJson: true };
+  }
+  if (objFiles.xmlFile) {
+    const xmlContent = await fileTree.read(objFiles.xmlFile);
+    const parsed = handler!.schema.parse(xmlContent);
+    return {
+      values: (parsed as any)?.abapGit?.abap?.values ?? {},
+      isAffJson: false,
+    };
+  }
+  return null;
+}
+
+/**
+ * Build the payload from handler or filename fallback.
+ */
+function buildPayload(
+  handler: ReturnType<typeof getHandler>,
+  values: Record<string, unknown>,
+  isAffJson: boolean,
+  objFiles: ObjectFiles,
+): { name: string; description?: string; [key: string]: unknown } {
+  if (isAffJson && handler?.fromAffJson) {
+    return values as { name: string; description?: string };
+  }
+  if (isAffJson) {
+    return { name: objFiles.name };
+  }
+  if (handler?.fromAbapGit) {
+    return handler.fromAbapGit(values);
+  }
+  return { name: objFiles.name };
+}
+
+/**
+ * Set sources on an ADK object using handler or fallback.
+ */
+function setObjectSources(
+  handler: ReturnType<typeof getHandler>,
+  adkObject: AdkObject,
+  sources: Record<string, string>,
+): void {
+  if (Object.keys(sources).length === 0) return;
+  if (handler?.setSources) {
+    handler.setSources(adkObject, sources);
+    return;
+  }
+  if (sources['main']) (adkObject as any)._pendingSource = sources['main'];
+  if (Object.keys(sources).length > 1) {
+    (adkObject as any)._pendingSources = sources;
+  }
+}
+
+/**
+ * Resolve packageRef on an ADK object from folder logic or rootPackage.
+ */
+function resolvePackageRef(
+  adkObject: AdkObject,
+  options: ExportOptions | undefined,
+  hasAbapGitXml: boolean,
+  folderLogic: import('./folder-logic').FolderLogic,
+): void {
+  if (!options?.rootPackage) return;
+  const data = (adkObject as any)._data;
+  if (!data || data.packageRef) return;
+  if (hasAbapGitXml) {
+    const relDir = (adkObject as any)._relDir ?? '';
+    const pkgName = resolvePackageFromDir(
+      relDir,
+      folderLogic,
+      options.rootPackage,
+    );
+    data.packageRef = { name: pkgName };
+  } else {
+    data.packageRef = { name: options.rootPackage };
+  }
+}
+
+/**
+ * Set abapLanguageVersion on an ADK object if provided in options.
+ */
+function setAbapLanguageVersion(
+  adkObject: AdkObject,
+  options: ExportOptions | undefined,
+): void {
+  if (!options?.abapLanguageVersion) return;
+  const data = (adkObject as any)._data;
+  if (data && !data.abapLanguageVersion) {
+    data.abapLanguageVersion =
+      abapLangVerToAdt(options.abapLanguageVersion) ??
+      options.abapLanguageVersion;
+  }
+}
+
+/**
  * Deserialize abapGit files to ADK objects
  *
  * True generator - yields objects one at a time as they're discovered.
@@ -62,23 +256,9 @@ export async function* deserialize(
   client: AdtClient,
   options?: ExportOptions,
 ): AsyncGenerator<AdkObject> {
-  // Get ADK factory for creating objects
   const adk = createAdk(client);
-
-  // Resolve folder logic from .abapgit.xml (optional — defaults used when missing)
-  let folderLogic: import('./folder-logic').FolderLogic = 'prefix';
-  let startDir = '';
-  const hasAbapGitXml = await fileTree.exists('.abapgit.xml');
-  if (hasAbapGitXml) {
-    try {
-      const xml = await fileTree.read('.abapgit.xml');
-      const meta = parseAbapGitMetadata(xml);
-      folderLogic = meta.folderLogic;
-      startDir = stripSlashes(meta.startingFolder);
-    } catch {
-      // Fall through to defaults if XML parsing fails
-    }
-  }
+  const { folderLogic, startDir, hasAbapGitXml } =
+    await resolveFolderConfig(fileTree);
 
   // Find all metadata files (XML = legacy, JSON = AFF)
   const [xmlFiles, jsonFiles] = await Promise.all([
@@ -86,207 +266,61 @@ export async function* deserialize(
     fileTree.glob('**/*.json'),
   ]);
 
-  // Filter to supported types and group by object
   const objectMap = new Map<string, ObjectFiles>();
   const supportedTypes = new Set(
     getSupportedTypes().map((t) => t.toLowerCase()),
   );
 
-  // Process XML metadata files (legacy abapGit format)
   for (const xmlPath of xmlFiles) {
-    // Skip .abapgit.xml metadata file
     if (xmlPath.endsWith('.abapgit.xml')) continue;
-
-    // Skip package.devc.xml - packages are not deployed, they must exist in target
     if (xmlPath.endsWith('package.devc.xml')) continue;
-
-    const filename = xmlPath.slice(xmlPath.lastIndexOf('/') + 1);
-    const parsed = parseAbapGitFilename(filename);
-
-    if (!parsed) continue;
-    if (!supportedTypes.has(parsed.type.toLowerCase())) continue;
-
-    // For compound objects (e.g., FUGR), multiple XML files share the same
-    // name:type key. Only the main XML (no suffix) is the metadata file;
-    // include XMLs (with suffix, e.g., PROGDIR) are sub-artifacts.
-    if (parsed.suffix) continue;
-
-    const key = `${parsed.name}:${parsed.type}`;
-
-    if (!objectMap.has(key)) {
-      objectMap.set(key, {
-        name: parsed.name,
-        type: parsed.type,
-        sourceFiles: [],
-      });
-    }
-
-    const obj = objectMap.get(key)!;
-    obj.xmlFile = xmlPath;
+    registerMetadataFile(xmlPath, supportedTypes, objectMap, 'xmlFile');
   }
 
-  // Process JSON metadata files (AFF format)
   for (const jsonPath of jsonFiles) {
-    const filename = jsonPath.slice(jsonPath.lastIndexOf('/') + 1);
-    const parsed = parseAbapGitFilename(filename);
-
-    if (!parsed) continue;
-    if (!supportedTypes.has(parsed.type.toLowerCase())) continue;
-
-    // JSON metadata files don't have suffixes
-    if (parsed.suffix) continue;
-
-    const key = `${parsed.name}:${parsed.type}`;
-
-    if (!objectMap.has(key)) {
-      objectMap.set(key, {
-        name: parsed.name,
-        type: parsed.type,
-        sourceFiles: [],
-      });
-    }
-
-    const obj = objectMap.get(key)!;
-    obj.jsonFile = jsonPath;
+    registerMetadataFile(jsonPath, supportedTypes, objectMap, 'jsonFile');
   }
 
-  // Find source files for each object (abap + AFF source extensions)
-  const [abapFiles, abdlFiles, acdsFiles, asrvdFiles] = await Promise.all([
-    fileTree.glob('**/*.abap'),
-    fileTree.glob('**/*.abdl'),
-    fileTree.glob('**/*.acds'),
-    fileTree.glob('**/*.asrvd'),
-  ]);
-  const sourceFiles = [...abapFiles, ...abdlFiles, ...acdsFiles, ...asrvdFiles];
-
-  for (const sourcePath of sourceFiles) {
-    const filename = sourcePath.slice(sourcePath.lastIndexOf('/') + 1);
-    const parsed = parseAbapGitFilename(filename);
-
-    if (!parsed) continue;
-
-    const key = `${parsed.name}:${parsed.type}`;
-    const obj = objectMap.get(key);
-
-    if (obj) {
-      obj.sourceFiles.push({ path: sourcePath, suffix: parsed.suffix });
-    }
-  }
+  await collectSourceFiles(fileTree, objectMap);
 
   // Process each object and yield
   for (const [, objFiles] of objectMap) {
-    // Must have at least one metadata file (XML or JSON)
     if (!objFiles.xmlFile && !objFiles.jsonFile) continue;
 
     const handler = getHandler(objFiles.type);
     if (!handler) continue;
 
     try {
-      let values: Record<string, unknown>;
-      let isAffJson = false;
+      const meta = await parseMetadata(fileTree, objFiles, handler);
+      if (!meta) continue;
+      const { values, isAffJson } = meta;
 
-      if (objFiles.jsonFile) {
-        // AFF JSON metadata file
-        const jsonContent = await fileTree.read(objFiles.jsonFile);
-        let jsonData: Record<string, unknown>;
-        try {
-          jsonData = JSON.parse(jsonContent) as Record<string, unknown>;
-        } catch (parseError) {
-          console.error(
-            `Failed to parse AFF JSON ${objFiles.jsonFile}:`,
-            parseError,
-          );
-          continue;
-        }
-        isAffJson = true;
-
-        // If handler has fromAffJson, use it; otherwise fall back to
-        // extracting values from the JSON body
-        if (handler.fromAffJson) {
-          const affPayload = handler.fromAffJson(jsonData);
-          values = affPayload as Record<string, unknown>;
-        } else {
-          // No fromAffJson — use the JSON body directly as values
-          values = jsonData;
-        }
-      } else if (objFiles.xmlFile) {
-        // Legacy XML metadata file
-        const xmlContent = await fileTree.read(objFiles.xmlFile);
-        const parsed = handler.schema.parse(xmlContent);
-        // Schema parses to { abapGit: { abap: { values: ... } } }
-        values = (parsed as any)?.abapGit?.abap?.values ?? {};
-      } else {
-        continue;
-      }
-
-      // Read source files, mapping suffixes using handler's suffixToSourceKey
+      // Read source files
       const sources: Record<string, string> = {};
       for (const { path, suffix } of objFiles.sourceFiles) {
         const content = await fileTree.read(path);
-        // Map suffix to source key using handler's mapping, or use suffix as-is
         const sourceKey = suffix
           ? (handler.suffixToSourceKey?.[suffix] ?? suffix)
           : 'main';
         sources[sourceKey] = content;
       }
 
-      // Get payload from handler (pure data mapping) or build default
-      let payload: {
-        name: string;
-        description?: string;
-        [key: string]: unknown;
-      };
-
-      if (isAffJson && handler.fromAffJson) {
-        // For AFF JSON, fromAffJson was already called above and returned
-        // the full payload (not just values)
-        payload = values as { name: string; description?: string };
-      } else if (isAffJson && !handler.fromAffJson) {
-        // No fromAffJson — use filename-derived name; JSON body is not
-        // compatible with fromAbapGit (which expects XML SKEY envelope)
-        payload = { name: objFiles.name };
-      } else if (handler.fromAbapGit) {
-        payload = handler.fromAbapGit(values);
-      } else {
-        payload = { name: objFiles.name };
-      }
-
-      // Use filename as fallback if name not in XML (e.g., DEVC)
+      const payload = buildPayload(handler, values, isAffJson, objFiles);
       const objectName = payload.name || objFiles.name;
-
-      // Build full data object with name
-      const fullData = { ...payload, name: objectName };
-
-      // Create ADK object with data (pre-loaded, no need to call load())
-      // Use payload type if available (e.g., TABL/DS for structures),
-      // falling back to filename-derived type
       const adkType =
         typeof payload.type === 'string' ? payload.type : objFiles.type;
-      const adkObject = adk.getWithData(fullData, adkType) as AdkObject;
+      const adkObject = adk.getWithData(
+        { ...payload, name: objectName },
+        adkType,
+      ) as AdkObject;
 
-      // Set sources on object using handler's setSources method
-      if (Object.keys(sources).length > 0) {
-        if (handler.setSources) {
-          handler.setSources(adkObject, sources);
-        } else {
-          // Fallback: store sources directly if handler doesn't provide setSources
-          if (sources['main']) {
-            (adkObject as any)._pendingSource = sources['main'];
-          }
-          if (Object.keys(sources).length > 1) {
-            (adkObject as any)._pendingSources = sources;
-          }
-        }
-      }
+      setObjectSources(handler, adkObject, sources);
 
-      // Store additional payload properties
       if (payload.description) {
         (adkObject as any)._pendingDescription = payload.description;
       }
 
-      // Compute relative directory and store on object for package resolution
-      // This metadata is always computed so the export command can auto-detect
-      // the root package from SAP and resolve packages later if needed.
+      // Compute relative directory for package resolution
       if (hasAbapGitXml) {
         const metadataFile = objFiles.xmlFile ?? objFiles.jsonFile ?? '';
         const sourceDir = metadataFile.split('/').slice(0, -1).join('/');
@@ -297,89 +331,58 @@ export async function* deserialize(
         (adkObject as any)._folderLogic = folderLogic;
       }
 
-      // Resolve packageRef when rootPackage is explicitly provided
-      if (options?.rootPackage) {
-        const data = (adkObject as any)._data;
-        if (data && !data.packageRef) {
-          if (hasAbapGitXml) {
-            const relDir = (adkObject as any)._relDir ?? '';
-            const pkgName = resolvePackageFromDir(
-              relDir,
-              folderLogic,
-              options.rootPackage,
-            );
-            data.packageRef = { name: pkgName };
-          } else {
-            // No .abapgit.xml: assign rootPackage directly
-            data.packageRef = { name: options.rootPackage };
-          }
-        }
-      }
-
-      // Set abapLanguageVersion if provided and not already set
-      // Map numeric codes ("5") to ADT values ("cloudDevelopment")
-      if (options?.abapLanguageVersion) {
-        const data = (adkObject as any)._data;
-        if (data && !data.abapLanguageVersion) {
-          data.abapLanguageVersion =
-            abapLangVerToAdt(options.abapLanguageVersion) ??
-            options.abapLanguageVersion;
-        }
-      }
+      resolvePackageRef(adkObject, options, hasAbapGitXml, folderLogic);
+      setAbapLanguageVersion(adkObject, options);
 
       yield adkObject;
 
       // For compound objects (FUGR), yield child objects (function modules)
       if (objFiles.type === 'FUGR' && payload._functions) {
-        const fmDescriptors = extractFunctionDescriptors(payload._functions);
-        const fmSources = (adkObject as any)._pendingFmSources as
-          Record<string, string> | undefined;
-
-        for (const fm of fmDescriptors) {
-          try {
-            // Build FM data object with _groupName for factory construction
-            const fmData: Record<string, unknown> = {
-              name: fm.funcName,
-              type: 'FUGR/FF',
-              _groupName: objectName, // parent FUGR name
-              description: fm.shortText ?? '',
-              processingType: fm.processingType,
-              basXMLEnabled: fm.basXMLEnabled,
-            };
-
-            const fmObject = adk.getWithData(fmData, 'FUGR/FF') as AdkObject;
-
-            // Set FM source if available
-            const fmSourceKey = fm.funcName.toLowerCase();
-            const fmSource = fmSources?.[fmSourceKey];
-            if (fmSource) {
-              (fmObject as any)._pendingSource = fmSource;
-            }
-
-            // Set abapLanguageVersion if provided
-            if (options?.abapLanguageVersion) {
-              const fmObjData = (fmObject as any)._data;
-              if (fmObjData && !fmObjData.abapLanguageVersion) {
-                fmObjData.abapLanguageVersion =
-                  abapLangVerToAdt(options.abapLanguageVersion) ??
-                  options.abapLanguageVersion;
-              }
-            }
-
-            yield fmObject;
-          } catch (fmError) {
-            console.error(
-              `Failed to deserialize FM ${fm.funcName} in FUGR ${objectName}:`,
-              fmError,
-            );
-          }
-        }
+        yield* yieldFugrChildren(adk, payload, objectName, options, adkObject);
       }
     } catch (error) {
-      // Log error but continue with other objects
       console.error(
         `Failed to deserialize ${objFiles.type} ${objFiles.name}:`,
         error,
+      );
+    }
+  }
+}
+
+/**
+ * Yield FUGR child function modules as separate ADK objects.
+ */
+async function* yieldFugrChildren(
+  adk: ReturnType<typeof createAdk>,
+  payload: { _functions?: unknown },
+  parentName: string,
+  options: ExportOptions | undefined,
+  parentObject: AdkObject,
+): AsyncGenerator<AdkObject> {
+  const fmDescriptors = extractFunctionDescriptors(payload._functions);
+  const fmSources = (parentObject as any)._pendingFmSources as
+    Record<string, string> | undefined;
+  for (const fm of fmDescriptors) {
+    try {
+      const fmObject = adk.getWithData(
+        {
+          name: fm.funcName,
+          type: 'FUGR/FF',
+          _groupName: parentName,
+          description: fm.shortText ?? '',
+          processingType: fm.processingType,
+          basXMLEnabled: fm.basXMLEnabled,
+        },
+        'FUGR/FF',
+      ) as AdkObject;
+      const fmSource = fmSources?.[fm.funcName.toLowerCase()];
+      if (fmSource) (fmObject as any)._pendingSource = fmSource;
+      setAbapLanguageVersion(fmObject, options);
+      yield fmObject;
+    } catch (fmError) {
+      console.error(
+        `Failed to deserialize FM ${fm.funcName} in FUGR ${parentName}:`,
+        fmError,
       );
     }
   }

--- a/packages/adt-plugin-abapgit/src/lib/filename-parser.ts
+++ b/packages/adt-plugin-abapgit/src/lib/filename-parser.ts
@@ -1,0 +1,45 @@
+/**
+ * abapGit filename parsing utilities.
+ *
+ * Extracted into a standalone module so it can be unit-tested without
+ * pulling in the full handler/schema dependency chain.
+ */
+
+/**
+ * abapGit file naming convention:
+ * - XML metadata: {name}.{type}.xml (e.g., zcl_myclass.clas.xml)
+ * - AFF JSON metadata: {name}.{type}.json (e.g., zfoo.bdef.json)
+ * - Source code: {name}.{type}.abap (e.g., zcl_myclass.clas.abap)
+ * - Source includes: {name}.{type}.{suffix}.abap (e.g., zcl_myclass.clas.testclasses.abap)
+ * - AFF source files: {name}.{type}.abdl, {name}.{type}.acds, {name}.{type}.asrvd
+ */
+
+/**
+ * Parse abapGit filename to extract object info
+ *
+ * Supports both legacy XML metadata (.xml) and AFF JSON metadata (.json),
+ * plus source file extensions (.abap, .abdl, .acds, .asrvd).
+ */
+export function parseAbapGitFilename(filename: string): {
+  name: string;
+  type: string;
+  suffix?: string;
+  extension: string;
+} | null {
+  // Match patterns like: name.type.xml, name.type.json, name.type.suffix.abap,
+  // name.type.<suffix>.abdl/.acds/.asrvd source files.
+  const match = filename.match(
+    /^([^.]+)\.([^.]+)(?:\.([^.]+))?\.(xml|json|abap|abdl|acds|asrvd)$/,
+  );
+  if (!match) return null;
+
+  const [, name, type, suffixOrExt, extension] = match;
+
+  // If 4 parts, middle is suffix; if 3 parts, no suffix
+  return {
+    name: name.toUpperCase(),
+    type: type.toUpperCase(),
+    suffix: suffixOrExt && suffixOrExt !== extension ? suffixOrExt : undefined,
+    extension,
+  };
+}

--- a/packages/adt-plugin-abapgit/src/lib/format-plugin.ts
+++ b/packages/adt-plugin-abapgit/src/lib/format-plugin.ts
@@ -70,9 +70,11 @@ async function buildMaterializedFiles(
   object: unknown,
   packageDir: string,
   sources?: Readonly<Record<string, string>>,
+  format?: 'aff' | 'legacy',
 ): Promise<MaterializedFormatFile[]> {
   const serialized = await handler.serialize(object, {
     ...(sources !== undefined ? { sources } : {}),
+    ...(format !== undefined ? { format } : {}),
   });
   return serialized
     .map((file): MaterializedFormatFile => {
@@ -134,6 +136,7 @@ export const abapgitFormatPlugin: FormatPlugin = {
       input.object,
       packageDir,
       input.sources,
+      input.formatOptions?.format as 'aff' | 'legacy' | undefined,
     );
     return { files };
   },

--- a/packages/adt-plugin-abapgit/src/lib/format-plugin.ts
+++ b/packages/adt-plugin-abapgit/src/lib/format-plugin.ts
@@ -31,7 +31,7 @@ function classifyFile(
   parsed: ParsedFilename,
   handler: FormatHandler,
 ): { role: 'metadata' } | { role: 'source'; sourceComponent: string } {
-  if (parsed.extension === 'xml') {
+  if (parsed.extension === 'xml' || parsed.extension === 'json') {
     return { role: 'metadata' };
   }
 

--- a/packages/adt-plugin-abapgit/src/lib/handlers/base.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/base.ts
@@ -96,6 +96,15 @@ export interface ObjectHandler<
   ): Partial<InferAdkData<T>> & { name: string };
 
   /**
+   * Map AFF JSON metadata to ADK data (Git → SAP)
+   * Used when the metadata file is `.json` (ABAP File Format) instead of legacy `.xml`.
+   * Receives the parsed JSON object and returns the full payload including name.
+   */
+  fromAffJson?(json: Record<string, unknown>): Partial<InferAdkData<T>> & {
+    name: string;
+  };
+
+  /**
    * Set source files on ADK object during deserialization (Git → SAP)
    * Symmetric counterpart to getSources
    */
@@ -208,6 +217,15 @@ export interface HandlerDefinition<
   fromAbapGit?(
     values: InferValuesType<TSchema>,
   ): Partial<InferAdkData<T>> & { name: string };
+
+  /**
+   * Map AFF JSON metadata to ADK data (Git → SAP)
+   * Used when the metadata file is `.json` (ABAP File Format) instead of legacy `.xml`.
+   * Receives the parsed JSON object and returns the full payload including name.
+   */
+  fromAffJson?(json: Record<string, unknown>): Partial<InferAdkData<T>> & {
+    name: string;
+  };
 
   /**
    * Map abapGit file suffix to source key (for objects with multiple sources)
@@ -610,6 +628,7 @@ export function createHandler<
         }
       : defaultSerialize,
     fromAbapGit: defaultFromAbapGit,
+    fromAffJson: definition.fromAffJson,
     setSources: definition.setSources,
   };
 

--- a/packages/adt-plugin-abapgit/src/lib/handlers/source-resolver.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/source-resolver.ts
@@ -162,3 +162,75 @@ export function affSetSources(obj: unknown, sources: { main?: string }): void {
       sources.main;
   }
 }
+
+/**
+ * Shared `fromAffJson` handler function for source-driven AFF objects.
+ * Extracts the object name from the JSON header or falls back to the
+ * filename-derived name passed in. The AFF JSON format stores the
+ * description in `header.description` and the original language in
+ * `header.originalLanguage`.
+ */
+export function affFromAffJson(
+  json: Record<string, unknown>,
+  fallbackName: string,
+): { name: string; description?: string } {
+  const header = json.header as
+    | { description?: string; originalLanguage?: string }
+    | undefined;
+  return {
+    name: fallbackName,
+    description: header?.description,
+  };
+}
+
+/**
+ * Dual-format serialize for objects that support both AFF JSON and legacy XML.
+ *
+ * When `options.format === 'legacy'`, produces a legacy abapGit XML metadata
+ * file (via `ctx.toAbapGitXml`) plus the source file. Otherwise (default or
+ * `format === 'aff'`), delegates to `serializeAffSource` to produce the AFF
+ * JSON sidecar plus source.
+ */
+export async function serializeDualFormat(
+  object: SourceObject & {
+    name: string;
+    description?: string;
+    originalLanguage?: string;
+    abapLanguageVersion?: string;
+  },
+  ctx: {
+    getObjectName: (obj: unknown) => string;
+    fileExtension: string;
+    createFile: (path: string, content: string) => SerializedFile;
+    toAbapGitXml: (obj: unknown) => string;
+  },
+  options: import('@abapify/adt-plugin').FormatSerializeOptions | undefined,
+  config: {
+    typeLabel: string;
+    sourceExt: string;
+    jsonExt: string;
+    extra?: Record<string, unknown>;
+  },
+): Promise<SerializedFile[]> {
+  // Legacy XML format: produce .xml metadata + source file
+  if (options?.format === 'legacy') {
+    const source = await resolveMainSource(object, options?.sources, config.typeLabel);
+    const name = ctx.getObjectName(object);
+    const files: SerializedFile[] = [];
+    // Source file (same extension as AFF)
+    if (source !== undefined && source !== '') {
+      files.push(
+        ctx.createFile(`${name}.${ctx.fileExtension}.${config.sourceExt}`, source),
+      );
+    }
+    // Legacy XML metadata
+    files.push(
+      ctx.createFile(`${name}.${ctx.fileExtension}.xml`, ctx.toAbapGitXml(object)),
+    );
+    return files;
+  }
+
+  // Default: AFF JSON format
+  return serializeAffSource(object, ctx, options?.sources, config);
+}
+

--- a/packages/adt-plugin-abapgit/src/lib/handlers/source-resolver.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/source-resolver.ts
@@ -168,18 +168,29 @@ export function affSetSources(obj: unknown, sources: { main?: string }): void {
  * Extracts the object name from the JSON header or falls back to the
  * filename-derived name passed in. The AFF JSON format stores the
  * description in `header.description` and the original language in
- * `header.originalLanguage`.
+ * `header.originalLanguage`. Both are preserved for round-trip fidelity.
  */
 export function affFromAffJson(
   json: Record<string, unknown>,
   fallbackName: string,
-): { name: string; description?: string } {
+): {
+  name: string;
+  description?: string;
+  originalLanguage?: string;
+  abapLanguageVersion?: string;
+} {
   const header = json.header as
-    | { description?: string; originalLanguage?: string }
+    | {
+        description?: string;
+        originalLanguage?: string;
+        abapLanguageVersion?: string;
+      }
     | undefined;
   return {
     name: fallbackName,
     description: header?.description,
+    originalLanguage: header?.originalLanguage,
+    abapLanguageVersion: header?.abapLanguageVersion,
   };
 }
 
@@ -217,8 +228,9 @@ export async function serializeDualFormat(
     const source = await resolveMainSource(object, options?.sources, config.typeLabel);
     const name = ctx.getObjectName(object);
     const files: SerializedFile[] = [];
-    // Source file (same extension as AFF)
-    if (source !== undefined && source !== '') {
+    // Source file — preserve explicitly supplied empty source (authoritative
+    // sources contract). Only skip when source is genuinely absent.
+    if (source !== undefined) {
       files.push(
         ctx.createFile(`${name}.${ctx.fileExtension}.${config.sourceExt}`, source),
       );

--- a/packages/adt-plugin-abapgit/src/lib/handlers/source-resolver.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/source-resolver.ts
@@ -225,19 +225,29 @@ export async function serializeDualFormat(
 ): Promise<SerializedFile[]> {
   // Legacy XML format: produce .xml metadata + source file
   if (options?.format === 'legacy') {
-    const source = await resolveMainSource(object, options?.sources, config.typeLabel);
+    const source = await resolveMainSource(
+      object,
+      options?.sources,
+      config.typeLabel,
+    );
     const name = ctx.getObjectName(object);
     const files: SerializedFile[] = [];
     // Source file — preserve explicitly supplied empty source (authoritative
     // sources contract). Only skip when source is genuinely absent.
     if (source !== undefined) {
       files.push(
-        ctx.createFile(`${name}.${ctx.fileExtension}.${config.sourceExt}`, source),
+        ctx.createFile(
+          `${name}.${ctx.fileExtension}.${config.sourceExt}`,
+          source,
+        ),
       );
     }
     // Legacy XML metadata
     files.push(
-      ctx.createFile(`${name}.${ctx.fileExtension}.xml`, ctx.toAbapGitXml(object)),
+      ctx.createFile(
+        `${name}.${ctx.fileExtension}.xml`,
+        ctx.toAbapGitXml(object),
+      ),
     );
     return files;
   }
@@ -245,4 +255,3 @@ export async function serializeDualFormat(
   // Default: AFF JSON format
   return serializeAffSource(object, ctx, options?.sources, config);
 }
-

--- a/packages/adt-plugin-abapgit/tests/filename-parsing.test.ts
+++ b/packages/adt-plugin-abapgit/tests/filename-parsing.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for parseAbapGitFilename — dual-format extension support
+ *
+ * Verifies that the filename parser correctly handles:
+ * - Legacy XML metadata (.xml)
+ * - AFF JSON metadata (.json)
+ * - ABAP source (.abap)
+ * - AFF source extensions (.abdl, .acds, .asrvd)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { parseAbapGitFilename } from '../src/lib/filename-parser.ts';
+
+describe('parseAbapGitFilename', () => {
+  describe('legacy XML metadata', () => {
+    it('parses name.type.xml', () => {
+      const result = parseAbapGitFilename('zcl_test.clas.xml');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZCL_TEST');
+      assert.strictEqual(result.type, 'CLAS');
+      assert.strictEqual(result.extension, 'xml');
+      assert.strictEqual(result.suffix, undefined);
+    });
+
+    it('parses package.devc.xml', () => {
+      const result = parseAbapGitFilename('package.devc.xml');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'PACKAGE');
+      assert.strictEqual(result.type, 'DEVC');
+      assert.strictEqual(result.extension, 'xml');
+    });
+  });
+
+  describe('AFF JSON metadata', () => {
+    it('parses name.type.json', () => {
+      const result = parseAbapGitFilename('zfoo.bdef.json');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZFOO');
+      assert.strictEqual(result.type, 'BDEF');
+      assert.strictEqual(result.extension, 'json');
+      assert.strictEqual(result.suffix, undefined);
+    });
+
+    it('parses srvd.json', () => {
+      const result = parseAbapGitFilename('zui_orders.srvd.json');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZUI_ORDERS');
+      assert.strictEqual(result.type, 'SRVD');
+      assert.strictEqual(result.extension, 'json');
+    });
+
+    it('parses ddls.json', () => {
+      const result = parseAbapGitFilename('zi_orders.ddls.json');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZI_ORDERS');
+      assert.strictEqual(result.type, 'DDLS');
+      assert.strictEqual(result.extension, 'json');
+    });
+
+    it('parses desd.json', () => {
+      const result = parseAbapGitFilename('zmy_schema.desd.json');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZMY_SCHEMA');
+      assert.strictEqual(result.type, 'DESD');
+      assert.strictEqual(result.extension, 'json');
+    });
+  });
+
+  describe('ABAP source files', () => {
+    it('parses name.type.abap', () => {
+      const result = parseAbapGitFilename('zcl_test.clas.abap');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZCL_TEST');
+      assert.strictEqual(result.type, 'CLAS');
+      assert.strictEqual(result.extension, 'abap');
+      assert.strictEqual(result.suffix, undefined);
+    });
+
+    it('parses name.type.suffix.abap', () => {
+      const result = parseAbapGitFilename('zcl_test.clas.testclasses.abap');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZCL_TEST');
+      assert.strictEqual(result.type, 'CLAS');
+      assert.strictEqual(result.extension, 'abap');
+      assert.strictEqual(result.suffix, 'testclasses');
+    });
+  });
+
+  describe('AFF source files', () => {
+    it('parses .abdl source (BDEF)', () => {
+      const result = parseAbapGitFilename('zbp_foo.bdef.abdl');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZBP_FOO');
+      assert.strictEqual(result.type, 'BDEF');
+      assert.strictEqual(result.extension, 'abdl');
+      assert.strictEqual(result.suffix, undefined);
+    });
+
+    it('parses .acds source (CDS types)', () => {
+      const result = parseAbapGitFilename('zi_orders.ddls.acds');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZI_ORDERS');
+      assert.strictEqual(result.type, 'DDLS');
+      assert.strictEqual(result.extension, 'acds');
+      assert.strictEqual(result.suffix, undefined);
+    });
+
+    it('parses .asrvd source (SRVD)', () => {
+      const result = parseAbapGitFilename('zui_orders.srvd.asrvd');
+      assert.ok(result);
+      assert.strictEqual(result.name, 'ZUI_ORDERS');
+      assert.strictEqual(result.type, 'SRVD');
+      assert.strictEqual(result.extension, 'asrvd');
+      assert.strictEqual(result.suffix, undefined);
+    });
+  });
+
+  describe('invalid filenames', () => {
+    it('returns null for .abapgit.xml', () => {
+      // .abapgit.xml has 4 parts but "abapgit" is not a valid type
+      // Actually this DOES parse — the deserializer filters it separately
+      const result = parseAbapGitFilename('.abapgit.xml');
+      // Leading dot means name is empty, which won't match the regex
+      assert.strictEqual(result, null);
+    });
+
+    it('returns null for unsupported extension', () => {
+      const result = parseAbapGitFilename('zfoo.bdef.txt');
+      assert.strictEqual(result, null);
+    });
+
+    it('returns null for random filename', () => {
+      const result = parseAbapGitFilename('README.md');
+      assert.strictEqual(result, null);
+    });
+  });
+});

--- a/packages/adt-plugin/src/index.ts
+++ b/packages/adt-plugin/src/index.ts
@@ -53,6 +53,7 @@ export type {
   FormatHandlerSchema,
   SerializedFile,
   FormatSerializeOptions,
+  AbapGitOutputFormat,
   MaterializedFormatFile,
   FormatMaterializationInput,
   FormatMaterializationResult,

--- a/packages/adt-plugin/src/lib/format/format-plugin.ts
+++ b/packages/adt-plugin/src/lib/format/format-plugin.ts
@@ -35,6 +35,9 @@ export interface SerializedFile {
   encoding?: BufferEncoding;
 }
 
+/** Output format for object types that support both legacy abapGit XML and AFF JSON. */
+export type AbapGitOutputFormat = 'aff' | 'legacy';
+
 /** Source contents selected independently from mutable object getters. */
 export interface FormatSerializeOptions {
   /**
@@ -44,6 +47,12 @@ export interface FormatSerializeOptions {
    * through the object model and MUST emit only the supplied components.
    */
   sources?: Readonly<Record<string, string>>;
+  /**
+   * Output format for object types that support both legacy abapGit XML and
+   * ABAP File Format (AFF) JSON. When omitted, the handler's default format
+   * is used (AFF for CDS/RAP types, legacy XML for DDIC/code types).
+   */
+  format?: AbapGitOutputFormat;
 }
 
 interface MaterializedFormatSourceFile extends SerializedFile {

--- a/packages/adt-plugin/src/lib/format/index.ts
+++ b/packages/adt-plugin/src/lib/format/index.ts
@@ -4,6 +4,7 @@ export type {
   FormatHandlerSchema,
   SerializedFile,
   FormatSerializeOptions,
+  AbapGitOutputFormat,
   MaterializedFormatFile,
   FormatMaterializationInput,
   FormatMaterializationResult,


### PR DESCRIPTION
## **User description**
## Summary

- Extend `parseAbapGitFilename` to recognize `.json` (AFF metadata) and `.acds` (CDS source) extensions
- Deserializer now globs for both `**/*.xml` and `**/*.json`, groups source sidecars, and dispatches to `fromAffJson` for JSON-based deserialization
- Add `fromAffJson?(json)` method to the `ObjectHandler` interface for AFF JSON deserialization
- Add `format?: 'aff' | 'legacy'` option to `FormatSerializeOptions` so callers can choose output format
- Add `serializeDualFormat` and `affFromAffJson` helpers in `source-resolver.ts`
- `format-plugin.ts` classifies `.json` as metadata role
- 14 filename parsing tests covering all extension combinations

This is the foundation PR for a stack of 4 PRs implementing comprehensive abapGit artifact support:
1. **This PR** — Dual-format deserialization architecture
2. Dual-format for 15 CDS/RAP types (BDEF, DCLS, DDLS, DDLX, SRVD, SRVB, etc.)
3. 7 new legacy XML types (MSAG, VIEW, ENQU, SHLP, TRAN, TYPE, XSLT)
4. 17 new AFF-first types (APLO, CHKC, CHKO, CHKV, SAJC, SAJT, etc.)

#### Test plan
- [x] `tsc --noEmit` passes for both `adt-plugin` and `adt-plugin-abapgit` packages
- [x] 14/14 filename parsing tests pass
- [ ] Full test suite (blocked by pre-existing `@abapify/ts-xsd` build issue)
- [ ] `npx nx codegen adt-plugin-abapgit` to regenerate schemas from XSD

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The abapGit deserializer previously recognized only legacy `.xml` metadata; it now also imports AFF `.json` metadata and `.abdl`, `.acds`, and `.asrvd` source files. Serialization can select AFF or legacy output with `FormatSerializeOptions.format`, while existing XML support remains available.

**Implementation**

- Adds optional `fromAffJson` mapping and shared AFF helpers; handlers without it fall back to filename-based objects instead of passing raw JSON through XML mapping.
- Forwards format selection to handlers, preserves AFF language metadata, and keeps explicitly empty supplied source content during legacy serialization.
- Skips malformed AFF JSON files without aborting the import and extracts filename parsing into a tested standalone module.
- Flattens the deserializer by extracting helpers for folder config, metadata parsing, source collection, and package resolution.

<sup>Written for commit 746ff040b2ec472212efedfe2475baa5f9a99be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing AFF JSON metadata alongside legacy XML metadata.
  - Added discovery of additional AFF source files, including `.acds` files.
  - Added configurable output formats for supported objects, including AFF JSON and legacy XML.
  - Added filename handling for AFF metadata and additional source file extensions.
  - Preserved language and version details when importing AFF source metadata.
- **Tests**
  - Added coverage for AFF, legacy, source, and invalid filename formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add dual-format abapGit import and export for AFF JSON and legacy XML

### What Changed
- Imports AFF `.json` metadata and associates `.abdl`, `.acds`, `.asrvd`, and `.abap` source files with the correct object
- Keeps legacy XML import available and uses filename-based fallback data when an AFF handler is unavailable
- Allows supported objects to be exported as AFF JSON by default or explicitly as legacy XML
- Preserves descriptions, language settings, and explicitly empty source files during round trips
- Skips malformed AFF JSON files without stopping processing of other repository objects
- Adds coverage for legacy metadata, AFF metadata, supported source extensions, and invalid filenames

### Impact
`✅ Import AFF JSON repositories`
`✅ Choose AFF JSON or legacy XML exports`
`✅ Fewer repository import failures from malformed metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
