### PR TITLE
feat(abapgit): dual-format support for 15 CDS/RAP object types

### DIFF
--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/bdef.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/bdef.ts
@@ -1,21 +1,28 @@
 /**
  * BDEF (RAP Behavior Definition) object handler for abapGit format
  *
- * BDEF is source-driven: the semantic content lives in an `.abdl` file and
- * the official ABAP File Format stores its metadata in a `.json` sidecar.
+ * BDEF is source-driven: the semantic content lives in an `.abdl` file.
+ * Supports BOTH formats:
+ *   - AFF (default): `.bdef.abdl` source + `.bdef.json` metadata sidecar
+ *   - Legacy XML:    `.bdef.abdl` source + `.bdef.xml` metadata
  *
- * File layout:
+ * File layout (AFF):
  *   src/zbp_foo.bdef.abdl — behavior source text
  *   src/zbp_foo.bdef.json — ABAP File Formats metadata
+ *
+ * File layout (legacy):
+ *   src/zbp_foo.bdef.abdl — behavior source text
+ *   src/zbp_foo.bdef.xml  — legacy abapGit XML metadata
  */
 
 import { bdef } from '../../../schemas/generated';
 import { createHandler } from '../base';
 import {
-  serializeAffSource,
+  serializeDualFormat,
   affGetSource,
   affFromAbapGit,
   affSetSources,
+  affFromAffJson,
 } from '../source-resolver';
 import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
@@ -44,9 +51,10 @@ export const behaviorDefinitionHandler = createHandler<BdefLike, typeof bdef>(
 
     getSource: affGetSource,
     fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
+    fromAffJson: (json) => affFromAffJson(json, ''),
 
     serialize: (object, ctx, options?: FormatSerializeOptions) =>
-      serializeAffSource(object, ctx, options?.sources, {
+      serializeDualFormat(object, ctx, options, {
         typeLabel: 'BDEF',
         sourceExt: 'abdl',
         jsonExt: `${ctx.fileExtension}.json`,

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/cds-aff-source.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/cds-aff-source.ts
@@ -1,5 +1,5 @@
 import { bdef } from '../../../schemas/generated';
-import { createHandler } from '../base';
+import { createHandler, type AbapGitSchema } from '../base';
 import {
   serializeDualFormat,
   affGetSource,
@@ -17,13 +17,26 @@ type CdsAffSourceObject = {
   getSource?: () => Promise<string> | string;
 };
 
+type CdsAffSourceOptions = {
+  /** Override the default bdef schema (for types with their own XSD) */
+  schema?: AbapGitSchema;
+  /** Extra AFF fields to include in fromAffJson (e.g. sourceOrigin, sourceType) */
+  fromAffJsonExtra?: (json: Record<string, unknown>) => Record<string, unknown>;
+  /** Extra fields to pass to serializeDualFormat, computed from the object */
+  serializeExtra?: (
+    object: CdsAffSourceObject & Record<string, unknown>,
+  ) => Record<string, unknown>;
+};
+
 /** Create the shared dual-format source-and-metadata layout used by CDS source types.
  * Supports both AFF JSON (default) and legacy abapGit XML metadata. */
 export function createCdsAffSourceHandler(
-  type: 'DRAS' | 'DRTY' | 'DSFD' | 'DTEB' | 'DTDC' | 'DTIX' | 'DTSC',
+  type: string,
+  options?: CdsAffSourceOptions,
 ) {
-  return createHandler<CdsAffSourceObject, typeof bdef>(type, {
-    schema: bdef,
+  const schema = options?.schema ?? bdef;
+  return createHandler<CdsAffSourceObject, typeof schema>(type, {
+    schema,
     version: 'v1.0.0',
     serializer: `LCL_OBJECT_${type}`,
     serializer_version: 'v1.0.0',
@@ -32,13 +45,17 @@ export function createCdsAffSourceHandler(
     }),
     getSource: affGetSource,
     fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
-    fromAffJson: (json) => affFromAffJson(json, ''),
+    fromAffJson: (json) =>
+      options?.fromAffJsonExtra
+        ? { ...affFromAffJson(json, ''), ...options.fromAffJsonExtra(json) }
+        : affFromAffJson(json, ''),
     setSources: affSetSources,
-    serialize: (object, ctx, options?: FormatSerializeOptions) =>
-      serializeDualFormat(object, ctx, options, {
+    serialize: (object, ctx, opts?: FormatSerializeOptions) =>
+      serializeDualFormat(object, ctx, opts, {
         typeLabel: type,
         sourceExt: 'acds',
         jsonExt: `${ctx.fileExtension}.json`,
+        extra: options?.serializeExtra?.(object),
       }),
   });
 }

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/cds-aff-source.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/cds-aff-source.ts
@@ -1,6 +1,12 @@
 import { bdef } from '../../../schemas/generated';
 import { createHandler } from '../base';
-import { serializeAffSource } from '../source-resolver';
+import {
+  serializeDualFormat,
+  affGetSource,
+  affFromAbapGit,
+  affSetSources,
+  affFromAffJson,
+} from '../source-resolver';
 import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
 type CdsAffSourceObject = {
@@ -11,7 +17,8 @@ type CdsAffSourceObject = {
   getSource?: () => Promise<string> | string;
 };
 
-/** Create the shared AFF source-and-metadata layout used by CDS source types. */
+/** Create the shared dual-format source-and-metadata layout used by CDS source types.
+ * Supports both AFF JSON (default) and legacy abapGit XML metadata. */
 export function createCdsAffSourceHandler(
   type: 'DRAS' | 'DRTY' | 'DSFD' | 'DTEB' | 'DTDC' | 'DTIX' | 'DTSC',
 ) {
@@ -23,8 +30,12 @@ export function createCdsAffSourceHandler(
     toAbapGit: (obj) => ({
       SKEY: { TYPE: type, NAME: String(obj?.name ?? '').toUpperCase() },
     }),
+    getSource: affGetSource,
+    fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
+    fromAffJson: (json) => affFromAffJson(json, ''),
+    setSources: affSetSources,
     serialize: (object, ctx, options?: FormatSerializeOptions) =>
-      serializeAffSource(object, ctx, options?.sources, {
+      serializeDualFormat(object, ctx, options, {
         typeLabel: type,
         sourceExt: 'acds',
         jsonExt: `${ctx.fileExtension}.json`,

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/dcls.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/dcls.ts
@@ -1,6 +1,21 @@
+/**
+ * DCLS (ABAP Data Control Language Source) object handler for abapGit format
+ *
+ * DCLS is source-driven: the semantic content lives in an `.acds` file.
+ * Supports BOTH formats:
+ *   - AFF (default): `.dcls.acds` source + `.dcls.json` metadata sidecar
+ *   - Legacy XML:    `.dcls.acds` source + `.dcls.xml` metadata
+ */
+
 import { dcls } from '../../../schemas/generated';
 import { createHandler } from '../base';
-import { serializeAffSource } from '../source-resolver';
+import {
+  serializeDualFormat,
+  affGetSource,
+  affFromAbapGit,
+  affSetSources,
+  affFromAffJson,
+} from '../source-resolver';
 import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
 type DclsLike = {
@@ -19,10 +34,14 @@ export const dclSourceHandler = createHandler<DclsLike, typeof dcls>('DCLS', {
   toAbapGit: (obj) => ({
     SKEY: { TYPE: 'DCLS', NAME: String(obj?.name ?? '').toUpperCase() },
   }),
+  getSource: affGetSource,
+  fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
+  fromAffJson: (json) => affFromAffJson(json, ''),
   serialize: (object, ctx, options?: FormatSerializeOptions) =>
-    serializeAffSource(object, ctx, options?.sources, {
+    serializeDualFormat(object, ctx, options, {
       typeLabel: 'DCLS',
       sourceExt: 'acds',
       jsonExt: 'dcls.json',
     }),
+  setSources: affSetSources,
 });

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/dcls.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/dcls.ts
@@ -8,40 +8,8 @@
  */
 
 import { dcls } from '../../../schemas/generated';
-import { createHandler } from '../base';
-import {
-  serializeDualFormat,
-  affGetSource,
-  affFromAbapGit,
-  affSetSources,
-  affFromAffJson,
-} from '../source-resolver';
-import type { FormatSerializeOptions } from '@abapify/adt-plugin';
+import { createCdsAffSourceHandler } from './cds-aff-source';
 
-type DclsLike = {
-  name: string;
-  description?: string;
-  originalLanguage?: string;
-  abapLanguageVersion?: string;
-  getSource?: () => Promise<string> | string;
-};
-
-export const dclSourceHandler = createHandler<DclsLike, typeof dcls>('DCLS', {
+export const dclSourceHandler = createCdsAffSourceHandler('DCLS', {
   schema: dcls,
-  version: 'v1.0.0',
-  serializer: 'LCL_OBJECT_DCLS',
-  serializer_version: 'v1.0.0',
-  toAbapGit: (obj) => ({
-    SKEY: { TYPE: 'DCLS', NAME: String(obj?.name ?? '').toUpperCase() },
-  }),
-  getSource: affGetSource,
-  fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
-  fromAffJson: (json) => affFromAffJson(json, ''),
-  serialize: (object, ctx, options?: FormatSerializeOptions) =>
-    serializeDualFormat(object, ctx, options, {
-      typeLabel: 'DCLS',
-      sourceExt: 'acds',
-      jsonExt: 'dcls.json',
-    }),
-  setSources: affSetSources,
 });

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddls.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddls.ts
@@ -1,6 +1,21 @@
+/**
+ * DDLS (Data Definition Language Source) object handler for abapGit format
+ *
+ * DDLS is source-driven: the semantic content lives in an `.acds` file.
+ * Supports BOTH formats:
+ *   - AFF (default): `.ddls.acds` source + `.ddls.json` metadata sidecar
+ *   - Legacy XML:    `.ddls.acds` source + `.ddls.xml` metadata
+ */
+
 import { ddls } from '../../../schemas/generated';
 import { createHandler } from '../base';
-import { serializeAffSource } from '../source-resolver';
+import {
+  serializeDualFormat,
+  affGetSource,
+  affFromAbapGit,
+  affSetSources,
+  affFromAffJson,
+} from '../source-resolver';
 import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
 type DdlsLike = {
@@ -21,8 +36,11 @@ export const ddlSourceHandler = createHandler<DdlsLike, typeof ddls>('DDLS', {
   toAbapGit: (obj) => ({
     SKEY: { TYPE: 'DDLS', NAME: String(obj?.name ?? '').toUpperCase() },
   }),
+  getSource: affGetSource,
+  fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
+  fromAffJson: (json) => affFromAffJson(json, ''),
   serialize: (object, ctx, options?: FormatSerializeOptions) =>
-    serializeAffSource(object, ctx, options?.sources, {
+    serializeDualFormat(object, ctx, options, {
       typeLabel: 'DDLS',
       sourceExt: 'acds',
       jsonExt: 'ddls.json',
@@ -31,4 +49,5 @@ export const ddlSourceHandler = createHandler<DdlsLike, typeof ddls>('DDLS', {
         sourceType: object.sourceType ?? 'unknown',
       },
     }),
+  setSources: affSetSources,
 });

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddls.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddls.ts
@@ -8,51 +8,16 @@
  */
 
 import { ddls } from '../../../schemas/generated';
-import { createHandler } from '../base';
-import {
-  serializeDualFormat,
-  affGetSource,
-  affFromAbapGit,
-  affSetSources,
-  affFromAffJson,
-} from '../source-resolver';
-import type { FormatSerializeOptions } from '@abapify/adt-plugin';
+import { createCdsAffSourceHandler } from './cds-aff-source';
 
-type DdlsLike = {
-  name: string;
-  description?: string;
-  originalLanguage?: string;
-  abapLanguageVersion?: string;
-  sourceOrigin?: string;
-  sourceType?: string;
-  getSource?: () => Promise<string> | string;
-};
-
-export const ddlSourceHandler = createHandler<DdlsLike, typeof ddls>('DDLS', {
+export const ddlSourceHandler = createCdsAffSourceHandler('DDLS', {
   schema: ddls,
-  version: 'v1.0.0',
-  serializer: 'LCL_OBJECT_DDLS',
-  serializer_version: 'v1.0.0',
-  toAbapGit: (obj) => ({
-    SKEY: { TYPE: 'DDLS', NAME: String(obj?.name ?? '').toUpperCase() },
-  }),
-  getSource: affGetSource,
-  fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
-  fromAffJson: (json) => ({
-    ...affFromAffJson(json, ''),
-    // Preserve DDLS-specific metadata for round-trip
+  fromAffJsonExtra: (json) => ({
     sourceOrigin: (json as { sourceOrigin?: string })?.sourceOrigin,
     sourceType: (json as { sourceType?: string })?.sourceType,
   }),
-  serialize: (object, ctx, options?: FormatSerializeOptions) =>
-    serializeDualFormat(object, ctx, options, {
-      typeLabel: 'DDLS',
-      sourceExt: 'acds',
-      jsonExt: 'ddls.json',
-      extra: {
-        sourceOrigin: object.sourceOrigin ?? 'abapDevelopmentTools',
-        sourceType: object.sourceType ?? 'unknown',
-      },
-    }),
-  setSources: affSetSources,
+  serializeExtra: (object) => ({
+    sourceOrigin: object.sourceOrigin ?? 'abapDevelopmentTools',
+    sourceType: object.sourceType ?? 'unknown',
+  }),
 });

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddls.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddls.ts
@@ -38,7 +38,12 @@ export const ddlSourceHandler = createHandler<DdlsLike, typeof ddls>('DDLS', {
   }),
   getSource: affGetSource,
   fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
-  fromAffJson: (json) => affFromAffJson(json, ''),
+  fromAffJson: (json) => ({
+    ...affFromAffJson(json, ''),
+    // Preserve DDLS-specific metadata for round-trip
+    sourceOrigin: (json as { sourceOrigin?: string })?.sourceOrigin,
+    sourceType: (json as { sourceType?: string })?.sourceType,
+  }),
   serialize: (object, ctx, options?: FormatSerializeOptions) =>
     serializeDualFormat(object, ctx, options, {
       typeLabel: 'DDLS',

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddlx.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddlx.ts
@@ -1,6 +1,21 @@
+/**
+ * DDLX (CDS Metadata Extension) object handler for abapGit format
+ *
+ * DDLX is source-driven: the semantic content lives in an `.acds` file.
+ * Supports BOTH formats:
+ *   - AFF (default): `.ddlx.acds` source + `.ddlx.json` metadata sidecar
+ *   - Legacy XML:    `.ddlx.acds` source + `.ddlx.xml` metadata
+ */
+
 import { ddlx } from '../../../schemas/generated';
 import { createHandler } from '../base';
-import { serializeAffSource } from '../source-resolver';
+import {
+  serializeDualFormat,
+  affGetSource,
+  affFromAbapGit,
+  affSetSources,
+  affFromAffJson,
+} from '../source-resolver';
 import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
 type DdlxLike = {
@@ -21,11 +36,15 @@ export const ddlExtensionHandler = createHandler<DdlxLike, typeof ddlx>(
     toAbapGit: (obj) => ({
       SKEY: { TYPE: 'DDLX', NAME: String(obj?.name ?? '').toUpperCase() },
     }),
+    getSource: affGetSource,
+    fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
+    fromAffJson: (json) => affFromAffJson(json, ''),
     serialize: (object, ctx, options?: FormatSerializeOptions) =>
-      serializeAffSource(object, ctx, options?.sources, {
+      serializeDualFormat(object, ctx, options, {
         typeLabel: 'DDLX',
         sourceExt: 'acds',
         jsonExt: 'ddlx.json',
       }),
+    setSources: affSetSources,
   },
 );

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddlx.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/ddlx.ts
@@ -8,43 +8,8 @@
  */
 
 import { ddlx } from '../../../schemas/generated';
-import { createHandler } from '../base';
-import {
-  serializeDualFormat,
-  affGetSource,
-  affFromAbapGit,
-  affSetSources,
-  affFromAffJson,
-} from '../source-resolver';
-import type { FormatSerializeOptions } from '@abapify/adt-plugin';
+import { createCdsAffSourceHandler } from './cds-aff-source';
 
-type DdlxLike = {
-  name: string;
-  description?: string;
-  originalLanguage?: string;
-  abapLanguageVersion?: string;
-  getSource?: () => Promise<string> | string;
-};
-
-export const ddlExtensionHandler = createHandler<DdlxLike, typeof ddlx>(
-  'DDLX',
-  {
-    schema: ddlx,
-    version: 'v1.0.0',
-    serializer: 'LCL_OBJECT_DDLX',
-    serializer_version: 'v1.0.0',
-    toAbapGit: (obj) => ({
-      SKEY: { TYPE: 'DDLX', NAME: String(obj?.name ?? '').toUpperCase() },
-    }),
-    getSource: affGetSource,
-    fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
-    fromAffJson: (json) => affFromAffJson(json, ''),
-    serialize: (object, ctx, options?: FormatSerializeOptions) =>
-      serializeDualFormat(object, ctx, options, {
-        typeLabel: 'DDLX',
-        sourceExt: 'acds',
-        jsonExt: 'ddlx.json',
-      }),
-    setSources: affSetSources,
-  },
-);
+export const ddlExtensionHandler = createCdsAffSourceHandler('DDLX', {
+  schema: ddlx,
+});

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/desd.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/desd.ts
@@ -1,5 +1,6 @@
 import { bdef } from '../../../schemas/generated';
 import { createHandler, type SerializedFile } from '../base';
+import { affFromAffJson } from '../source-resolver';
 
 type DesdLike = {
   name: string;
@@ -17,6 +18,7 @@ export const externalSchemaHandler = createHandler<DesdLike, typeof bdef>(
     toAbapGit: (obj) => ({
       SKEY: { TYPE: 'DESD', NAME: String(obj?.name ?? '').toUpperCase() },
     }),
+    fromAffJson: (json) => affFromAffJson(json, ''),
     async serialize(object, ctx): Promise<SerializedFile[]> {
       const header = {
         description: object.description || String(object.name ?? ''),

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/dsfi.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/dsfi.ts
@@ -66,8 +66,12 @@ export const scalarFunctionImplementationHandler = createHandler<
   fromAffJson: (json) => {
     const def = json as Partial<DsfiDefinition> | undefined;
     return {
-      name: String(def?.scalarFunctionName ?? '').toUpperCase(),
+      // Use filename-derived name (injected by deserializer); scalarFunctionName
+      // is a reference, not the object identity.
+      name: '',
       description: def?.header?.description,
+      originalLanguage: def?.header?.originalLanguage,
+      abapLanguageVersion: def?.header?.abapLanguageVersion,
     };
   },
   async serialize(object, ctx): Promise<SerializedFile[]> {

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/dsfi.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/dsfi.ts
@@ -63,6 +63,13 @@ export const scalarFunctionImplementationHandler = createHandler<
   toAbapGit: (obj) => ({
     SKEY: { TYPE: 'DSFI', NAME: String(obj?.name ?? '').toUpperCase() },
   }),
+  fromAffJson: (json) => {
+    const def = json as Partial<DsfiDefinition> | undefined;
+    return {
+      name: String(def?.scalarFunctionName ?? '').toUpperCase(),
+      description: def?.header?.description,
+    };
+  },
   async serialize(object, ctx): Promise<SerializedFile[]> {
     const definition = parseDsfiDefinition(
       typeof object.getSource === 'function'

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvb.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvb.ts
@@ -51,8 +51,24 @@ export const serviceBindingHandler = createHandler<SrvbLike, typeof srvb>(
     }),
 
     fromAffJson: (json) => {
-      const header = (json as { header?: { description?: string; originalLanguage?: string; abapLanguageVersion?: string } })?.header;
-      const binding = (json as { binding?: { bindingType?: string; bindingTypeCategory?: string; services?: unknown[] } })?.binding;
+      const header = (
+        json as {
+          header?: {
+            description?: string;
+            originalLanguage?: string;
+            abapLanguageVersion?: string;
+          };
+        }
+      )?.header;
+      const binding = (
+        json as {
+          binding?: {
+            bindingType?: string;
+            bindingTypeCategory?: string;
+            services?: unknown[];
+          };
+        }
+      )?.binding;
       return {
         // Filename-derived name (injected by deserializer)
         name: '',
@@ -67,13 +83,23 @@ export const serviceBindingHandler = createHandler<SrvbLike, typeof srvb>(
     },
 
     // Metadata-only: emit either .xml (legacy) or .json (AFF) depending on format option.
-    async serialize(object, ctx, options?: FormatSerializeOptions): Promise<SerializedFile[]> {
+    async serialize(
+      object,
+      ctx,
+      options?: FormatSerializeOptions,
+    ): Promise<SerializedFile[]> {
       const objectName = ctx.getObjectName(object);
 
       // AFF JSON format
       if (options?.format === 'aff') {
-        const bindingType = String(object?.bindingType ?? object?.data?.bindingType ?? 'odataV4');
-        const bindingTypeCategory = String(object?.bindingTypeCategory ?? object?.data?.bindingTypeCategory ?? 'odata_v4_ui');
+        const bindingType = String(
+          object?.bindingType ?? object?.data?.bindingType ?? 'odataV4',
+        );
+        const bindingTypeCategory = String(
+          object?.bindingTypeCategory ??
+            object?.data?.bindingTypeCategory ??
+            'odata_v4_ui',
+        );
         const services = object?.services ?? object?.data?.services ?? [];
         const jsonContent = buildAffJson(
           String(object?.description ?? object?.name ?? ''),
@@ -83,12 +109,17 @@ export const serviceBindingHandler = createHandler<SrvbLike, typeof srvb>(
             binding: {
               bindingType,
               bindingTypeCategory,
-              ...(Array.isArray(services) && services.length > 0 ? { services } : {}),
+              ...(Array.isArray(services) && services.length > 0
+                ? { services }
+                : {}),
             },
           },
         );
         return [
-          ctx.createFile(`${objectName}.${ctx.fileExtension}.json`, jsonContent),
+          ctx.createFile(
+            `${objectName}.${ctx.fileExtension}.json`,
+            jsonContent,
+          ),
         ];
       }
 

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvb.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvb.ts
@@ -50,10 +50,21 @@ export const serviceBindingHandler = createHandler<SrvbLike, typeof srvb>(
       name: String(SKEY?.NAME ?? '').toUpperCase(),
     }),
 
-    fromAffJson: (json) => ({
-      name: String((json as { header?: { name?: string } })?.header?.name ?? '').toUpperCase(),
-      description: (json as { header?: { description?: string } })?.header?.description,
-    }),
+    fromAffJson: (json) => {
+      const header = (json as { header?: { description?: string; originalLanguage?: string; abapLanguageVersion?: string } })?.header;
+      const binding = (json as { binding?: { bindingType?: string; bindingTypeCategory?: string; services?: unknown[] } })?.binding;
+      return {
+        // Filename-derived name (injected by deserializer)
+        name: '',
+        description: header?.description,
+        originalLanguage: header?.originalLanguage,
+        abapLanguageVersion: header?.abapLanguageVersion,
+        // Preserve binding metadata for round-trip
+        bindingType: binding?.bindingType,
+        bindingTypeCategory: binding?.bindingTypeCategory,
+        services: binding?.services,
+      };
+    },
 
     // Metadata-only: emit either .xml (legacy) or .json (AFF) depending on format option.
     async serialize(object, ctx, options?: FormatSerializeOptions): Promise<SerializedFile[]> {
@@ -61,10 +72,20 @@ export const serviceBindingHandler = createHandler<SrvbLike, typeof srvb>(
 
       // AFF JSON format
       if (options?.format === 'aff') {
+        const bindingType = String(object?.bindingType ?? object?.data?.bindingType ?? 'odataV4');
+        const bindingTypeCategory = String(object?.bindingTypeCategory ?? object?.data?.bindingTypeCategory ?? 'odata_v4_ui');
+        const services = object?.services ?? object?.data?.services ?? [];
         const jsonContent = buildAffJson(
           String(object?.description ?? object?.name ?? ''),
           String(object?.originalLanguage ?? 'en'),
           object?.abapLanguageVersion,
+          {
+            binding: {
+              bindingType,
+              bindingTypeCategory,
+              ...(Array.isArray(services) && services.length > 0 ? { services } : {}),
+            },
+          },
         );
         return [
           ctx.createFile(`${objectName}.${ctx.fileExtension}.json`, jsonContent),

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvb.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvb.ts
@@ -1,12 +1,16 @@
 /**
  * SRVB (RAP Service Binding) object handler for abapGit format
  *
- * Unlike BDEF/SRVD, SRVB is **metadata-only** — there is no `.abdl`/
- * `.asrvd`-style source text. The handler writes a single
- * `<name>.srvb.xml` file carrying a minimal SKEY + BINDING block.
+ * Unlike BDEF/SRVD, SRVB is **metadata-only** — there is no source text.
+ * Supports BOTH formats:
+ *   - Legacy XML (default): `<name>.srvb.xml` with SKEY + BINDING block
+ *   - AFF JSON:             `<name>.srvb.json` with formatVersion + header
  *
- * File layout:
+ * File layout (legacy):
  *   src/zui_foo.srvb.xml     — metadata only
+ *
+ * File layout (AFF):
+ *   src/zui_foo.srvb.json    — metadata only
  *
  * Mirrors the minimal-block approach used by
  * zcl_abapgit_object_srvb (abapGit upstream serialiser).
@@ -14,6 +18,8 @@
 
 import { srvb } from '../../../schemas/generated';
 import { createHandler, type SerializedFile } from '../base';
+import { buildAffJson } from '../source-resolver';
+import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
 // SRVB is not derived from AdkObject — we cast to the minimal handler shape
 // via the string form of createHandler.
@@ -44,9 +50,28 @@ export const serviceBindingHandler = createHandler<SrvbLike, typeof srvb>(
       name: String(SKEY?.NAME ?? '').toUpperCase(),
     }),
 
-    // Metadata-only: emit just <name>.srvb.xml (no source file).
-    async serialize(object, ctx): Promise<SerializedFile[]> {
+    fromAffJson: (json) => ({
+      name: String((json as { header?: { name?: string } })?.header?.name ?? '').toUpperCase(),
+      description: (json as { header?: { description?: string } })?.header?.description,
+    }),
+
+    // Metadata-only: emit either .xml (legacy) or .json (AFF) depending on format option.
+    async serialize(object, ctx, options?: FormatSerializeOptions): Promise<SerializedFile[]> {
       const objectName = ctx.getObjectName(object);
+
+      // AFF JSON format
+      if (options?.format === 'aff') {
+        const jsonContent = buildAffJson(
+          String(object?.description ?? object?.name ?? ''),
+          String(object?.originalLanguage ?? 'en'),
+          object?.abapLanguageVersion,
+        );
+        return [
+          ctx.createFile(`${objectName}.${ctx.fileExtension}.json`, jsonContent),
+        ];
+      }
+
+      // Default: legacy XML format
       const xmlContent = ctx.toAbapGitXml(object);
       return [
         ctx.createFile(`${objectName}.${ctx.fileExtension}.xml`, xmlContent),

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvd.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvd.ts
@@ -56,8 +56,10 @@ export const serviceDefinitionHandler = createHandler<SrvdLike, typeof srvd>(
     fromAffJson: (json) => ({
       ...affFromAffJson(json, ''),
       // Preserve SRVD-specific metadata for round-trip
-      sourceOrigin: (json as { generalInformation?: { sourceOrigin?: string } })?.generalInformation?.sourceOrigin,
-      sourceType: (json as { generalInformation?: { sourceType?: string } })?.generalInformation?.sourceType,
+      sourceOrigin: (json as { generalInformation?: { sourceOrigin?: string } })
+        ?.generalInformation?.sourceOrigin,
+      sourceType: (json as { generalInformation?: { sourceType?: string } })
+        ?.generalInformation?.sourceType,
     }),
 
     serialize: (object, ctx, options?: FormatSerializeOptions) =>

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvd.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvd.ts
@@ -53,7 +53,12 @@ export const serviceDefinitionHandler = createHandler<SrvdLike, typeof srvd>(
 
     getSource: affGetSource,
     fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
-    fromAffJson: (json) => affFromAffJson(json, ''),
+    fromAffJson: (json) => ({
+      ...affFromAffJson(json, ''),
+      // Preserve SRVD-specific metadata for round-trip
+      sourceOrigin: (json as { generalInformation?: { sourceOrigin?: string } })?.generalInformation?.sourceOrigin,
+      sourceType: (json as { generalInformation?: { sourceType?: string } })?.generalInformation?.sourceType,
+    }),
 
     serialize: (object, ctx, options?: FormatSerializeOptions) =>
       serializeDualFormat(object, ctx, options, {

--- a/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvd.ts
+++ b/packages/adt-plugin-abapgit/src/lib/handlers/objects/srvd.ts
@@ -1,21 +1,28 @@
 /**
  * SRVD (RAP Service Definition) object handler for abapGit format
  *
- * SRVD is source-driven: the semantic content lives in an `.acds` file and
- * the official ABAP File Format stores its metadata in a `.json` sidecar.
+ * SRVD is source-driven: the semantic content lives in an `.acds` file.
+ * Supports BOTH formats:
+ *   - AFF (default): `.srvd.acds` source + `.srvd.json` metadata sidecar
+ *   - Legacy XML:    `.srvd.acds` source + `.srvd.xml` metadata
  *
- * File layout:
+ * File layout (AFF):
  *   src/zui_foo.srvd.acds — service source text
  *   src/zui_foo.srvd.json — ABAP File Formats metadata
+ *
+ * File layout (legacy):
+ *   src/zui_foo.srvd.acds — service source text
+ *   src/zui_foo.srvd.xml  — legacy abapGit XML metadata
  */
 
 import { srvd } from '../../../schemas/generated';
 import { createHandler } from '../base';
 import {
-  serializeAffSource,
+  serializeDualFormat,
   affGetSource,
   affFromAbapGit,
   affSetSources,
+  affFromAffJson,
 } from '../source-resolver';
 import type { FormatSerializeOptions } from '@abapify/adt-plugin';
 
@@ -46,9 +53,10 @@ export const serviceDefinitionHandler = createHandler<SrvdLike, typeof srvd>(
 
     getSource: affGetSource,
     fromAbapGit: ({ SKEY }) => affFromAbapGit(SKEY),
+    fromAffJson: (json) => affFromAffJson(json, ''),
 
     serialize: (object, ctx, options?: FormatSerializeOptions) =>
-      serializeAffSource(object, ctx, options?.sources, {
+      serializeDualFormat(object, ctx, options, {
         typeLabel: 'SRVD',
         sourceExt: 'acds',
         jsonExt: `${ctx.fileExtension}.json`,


### PR DESCRIPTION
## **User description**
## Summary

- Upgrade BDEF, DCLS, DDLS, DDLX, SRVD, SRVB, DRAS, DRTY, DSFD, DSFI, DTEB, DTDC, DTIX, DTSC, DESD to support **both** AFF JSON (default) and legacy XML serialization/deserialization
- Each handler now has `fromAbapGit` (legacy XML), `fromAffJson` (AFF JSON), and `serializeDualFormat` which dispatches based on the `format` option
- BDEF, DCLS, DDLS, DDLX, SRVD: use `serializeDualFormat` (AFF default, legacy XML via `format: 'legacy'`)
- SRVB: legacy XML default, AFF JSON via `format: 'aff'`
- DESD, DSFI: added `fromAffJson` for JSON deserialization

Stack: builds on #198 (dual-format foundation)

#### Test plan
- [x] `tsc --noEmit` passes
- [ ] Full test suite (blocked by pre-existing `@abapify/ts-xsd` build issue)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dual-format AFF JSON and legacy XML serialization/deserialization for 15 CDS/RAP object types. Source-driven handlers keep AFF JSON as their default and gain legacy XML output via `format: 'legacy'`; SRVB keeps legacy XML as its default and gains AFF JSON via `format: 'aff'`.

- Adds AFF JSON deserialization for source metadata, DESD, DSFI, and SRVB alongside the existing XML paths.
- Preserves language/version, source-origin metadata, and SRVB binding details in AFF round trips.
- DSFI names resolve from the filename rather than `scalarFunctionName`, which is a reference.
- Refactors DCLS, DDLS, and DDLX onto a shared `createCdsAffSourceHandler` factory to avoid duplication.
- `tsc --noEmit` passes; the full test suite remains blocked by a pre-existing `@abapify/ts-xsd` build issue.

<sup>Written for commit eb35459554874894e5454882bf9abed2f56f1183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add dual-format serialization for CDS and RAP objects

### What Changed
- CDS and RAP objects can now be saved and loaded as either AFF JSON or legacy XML, with AFF JSON as the default for source-driven objects
- RAP service bindings support AFF JSON while retaining legacy XML as the default
- AFF imports preserve object names, language settings, source metadata, binding details, and service lists for accurate round trips
- Added AFF JSON loading for external schemas and scalar function implementations

### Impact
`✅ AFF JSON support across 15 CDS/RAP object types`
`✅ Legacy XML compatibility for existing repositories`
`✅ More accurate metadata round trips`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
